### PR TITLE
fix: switch to artist

### DIFF
--- a/custom_components/yoto/media_player.py
+++ b/custom_components/yoto/media_player.py
@@ -121,7 +121,7 @@ class YotoMediaPlayer(MediaPlayerEntity, YotoEntity):
         return self.player.track_length
 
     @property
-    def media_album_artist(self) -> str:
+    def media_artist(self) -> str:
         if self.media_content_id in self.coordinator.yoto_manager.library:
             return self.coordinator.yoto_manager.library[self.media_content_id].author
         else:


### PR DESCRIPTION
Makes it so artist is shown on dashboards like the sonos one: 

![image](https://github.com/cdnninja/yoto_ha/assets/6373468/afbd89a8-4457-4f87-83fc-a0482c0cef99)


@cjb0001 thoughts on this? 