### PR TITLE
fix: Update media_player.py to remove _media_player appendage

### DIFF
--- a/custom_components/yoto/media_player.py
+++ b/custom_components/yoto/media_player.py
@@ -54,7 +54,7 @@ class YotoMediaPlayer(MediaPlayerEntity, YotoEntity):
         # self.data = data
         self._key = "media_player"
         self._attr_unique_id = f"{DOMAIN}_{player.id}_media_player"
-        self._attr_name = "Media Player"
+        self._attr_name = None
         self._attr_device_class = MediaPlayerDeviceClass.SPEAKER
         self._currently_playing: dict | None = {}
         self._attr_volume_step = 0.0625


### PR DESCRIPTION
Set the `_attr_name` of the `media_player` entity to "None" to remove the "Media Player" entity name/id appendage, as per the [docs](https://developers.home-assistant.io/docs/core/entity#example-of-a-switch-entity-which-is-the-main-feature-of-a-device).

Should fix https://github.com/cdnninja/yoto_ha/issues/49