### PR TITLE
feat: add opus mime type to error

### DIFF
--- a/custom_components/yoto/media_source.py
+++ b/custom_components/yoto/media_source.py
@@ -53,7 +53,9 @@ class YotoMediaSource(MediaSource):
         elif track.format == "opus":
             mime = "audio/opus"
         else:
-            _LOGGER.error(f"Unknown track format: {track.format}. Report this to the developer on GitHub.")
+            _LOGGER.error(
+                f"Unknown track format: {track.format}. Report this to the developer on GitHub."
+            )
         return PlayMedia(track.trackUrl, mime)
 
     async def async_browse_media(


### PR DESCRIPTION
Seems some content may be OPUS.  This change causes opus to report to HA.  So if the system doesn't support it an error occurs, like the browser. 