### PR TITLE
refactor: migrate to runtime_data and register services in async_setup

### DIFF
--- a/custom_components/yoto/__init__.py
+++ b/custom_components/yoto/__init__.py
@@ -1,3 +1,5 @@
+"""Yoto integration."""
+
 import asyncio
 import logging
 
@@ -6,10 +8,11 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.device_registry import DeviceEntry
+from homeassistant.helpers.typing import ConfigType
 from yoto_api import AuthenticationError
 
 from .const import CONF_TOKEN, DOMAIN
-from .coordinator import YotoDataUpdateCoordinator
+from .coordinator import YotoConfigEntry, YotoDataUpdateCoordinator
 from .media_source import YotoMediaSource
 from .services import async_setup_services
 
@@ -26,11 +29,13 @@ PLATFORMS: list[str] = [
 ]
 
 
-async def async_setup(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Yoto component."""
+    async_setup_services(hass)
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, config_entry: YotoConfigEntry) -> bool:
     """Set up Yoto from a config entry."""
     coordinator = YotoDataUpdateCoordinator(hass, config_entry)
     try:
@@ -40,41 +45,35 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         _LOGGER.error(f"Authentication error: {ex}")
         raise ConfigEntryAuthFailed from ex
 
+    config_entry.runtime_data = coordinator
+
     async def _handle_shutdown(event):
         new_data = dict(config_entry.data)
-        coordinator = hass.data[DOMAIN][config_entry.unique_id]
         new_data[CONF_TOKEN] = coordinator.yoto_manager.token.refresh_token
         _LOGGER.debug("Storing token on HA shutdown.")
         hass.config_entries.async_update_entry(config_entry, data=new_data)
 
     hass.bus.async_listen_once("homeassistant_stop", _handle_shutdown)
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][config_entry.unique_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
-    async_setup_services(hass)
 
-    # Register the media source
     hass.data.setdefault("media_source", {})
     hass.data["media_source"][DOMAIN] = YotoMediaSource(hass)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: YotoConfigEntry) -> bool:
     """Handle removal of an entry."""
-    new_data = dict(entry.data)
-    coordinator = hass.data[DOMAIN][entry.unique_id]
+    coordinator = entry.runtime_data
     if coordinator.yoto_manager.token.refresh_token != entry.data.get(CONF_TOKEN):
+        new_data = dict(entry.data)
         new_data[CONF_TOKEN] = coordinator.yoto_manager.token.refresh_token
         _LOGGER.debug("Storing token on unload")
         hass.config_entries.async_update_entry(entry, data=new_data)
 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        release_tasks = set()
-        release_tasks.add(coordinator.release())
-        hass.data[DOMAIN].pop(entry.unique_id)
-        await asyncio.gather(*release_tasks)
+        await coordinator.release()
     return unload_ok
 
 
@@ -91,7 +90,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_remove_config_entry_device(
-    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: DeviceEntry
+    hass: HomeAssistant, config_entry: YotoConfigEntry, device_entry: DeviceEntry
 ) -> bool:
     """Remove a config entry from a device."""
     return True

--- a/custom_components/yoto/binary_sensor.py
+++ b/custom_components/yoto/binary_sensor.py
@@ -12,14 +12,13 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from yoto_api import YotoPlayer
 
 from .const import DOMAIN
-from .coordinator import YotoDataUpdateCoordinator
+from .coordinator import YotoConfigEntry, YotoDataUpdateCoordinator
 from .entity import YotoEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -81,11 +80,11 @@ SENSOR_DESCRIPTIONS: Final[tuple[YotoBinarySensorEntityDescription, ...]] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: YotoConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up binary_sensor platform."""
-    coordinator = hass.data[DOMAIN][config_entry.unique_id]
+    coordinator = config_entry.runtime_data
     entities: list[YotoBinarySensor] = []
     for player_id in coordinator.yoto_manager.players.keys():
         player: YotoPlayer = coordinator.yoto_manager.players[player_id]

--- a/custom_components/yoto/config_flow.py
+++ b/custom_components/yoto/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for Hyundai / Kia Connect integration."""
+"""Config flow for Yoto integration."""
 
 from __future__ import annotations
 

--- a/custom_components/yoto/coordinator.py
+++ b/custom_components/yoto/coordinator.py
@@ -16,11 +16,13 @@ from .const import CONF_TOKEN, DEFAULT_SCAN_INTERVAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+type YotoConfigEntry = ConfigEntry["YotoDataUpdateCoordinator"]
+
 
 class YotoDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the API."""
 
-    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    def __init__(self, hass: HomeAssistant, config_entry: YotoConfigEntry) -> None:
         """Initialize."""
         self.platforms: set[str] = set()
         self.config_entry = config_entry

--- a/custom_components/yoto/entity.py
+++ b/custom_components/yoto/entity.py
@@ -1,6 +1,4 @@
-"""Base Entity for Hyundai / Kia Connect integration."""
-
-import logging
+"""Base entity for Yoto integration."""
 
 from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo
@@ -8,11 +6,9 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 
-_LOGGER = logging.getLogger(__name__)
-
 
 class YotoEntity(CoordinatorEntity):
-    """Class for base entity for Yoto integration."""
+    """Base entity for Yoto integration."""
 
     _attr_has_entity_name = True
 
@@ -34,23 +30,7 @@ class YotoEntity(CoordinatorEntity):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
+        # Coordinator's api_callback fires from the paho-mqtt thread, so route
+        # the state write through the thread-safe scheduler instead of the
+        # default async_write_ha_state.
         self.schedule_update_ha_state()
-        """if not self.enabled:
-            return
-        else:
-
-            if self.player.card_id and self.player.chapter_key:
-                _LOGGER.debug(f"{DOMAIN} - Card ID:  {self.player.card_id} Chapter Key: {self.player.chapter_key}")
-
-                if not (
-                    self.player.chapter_key
-                    in self.coordinator.yoto_manager.library[self.player.card_id].chapters
-                ):
-                    _LOGGER.debug(f"{DOMAIN} - updating card details:  {self.player.card_id}")
-                    return asyncio.run_coroutine_threadsafe(
-                        self.coordinator.async_update_card_detail(self.player.card_id),
-                else:
-                    _LOGGER.debug(f"{DOMAIN} - Chapter Details not missing")
-
-"""

--- a/custom_components/yoto/light.py
+++ b/custom_components/yoto/light.py
@@ -12,12 +12,12 @@ from homeassistant.components.light import (
     LightEntity,
     LightEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from yoto_api import YotoPlayer
 
 from .const import DOMAIN
+from .coordinator import YotoConfigEntry
 from .entity import YotoEntity
 from .utils import rgetattr
 
@@ -37,11 +37,11 @@ SENSOR_DESCRIPTIONS: Final[tuple[LightEntityDescription, ...]] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: YotoConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up sensor platform."""
-    coordinator = hass.data[DOMAIN][config_entry.unique_id]
+    coordinator = config_entry.runtime_data
     entities: list[YotoLight] = []
     for player_id in coordinator.yoto_manager.players.keys():
         player: YotoPlayer = coordinator.yoto_manager.players[player_id]

--- a/custom_components/yoto/media_player.py
+++ b/custom_components/yoto/media_player.py
@@ -16,12 +16,12 @@ from homeassistant.components.media_player import (
     MediaPlayerState,
     MediaType,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from yoto_api import YotoPlayer
 
 from .const import DOMAIN
+from .coordinator import YotoConfigEntry
 from .entity import YotoEntity
 from .utils import split_media_id
 
@@ -30,11 +30,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: YotoConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Media Player platform."""
-    coordinator = hass.data[DOMAIN][config_entry.unique_id]
+    coordinator = config_entry.runtime_data
     entities: list[YotoMediaPlayer] = []
     for player_id in coordinator.yoto_manager.players.keys():
         player: YotoPlayer = coordinator.yoto_manager.players[player_id]

--- a/custom_components/yoto/media_source.py
+++ b/custom_components/yoto/media_source.py
@@ -9,6 +9,7 @@ from homeassistant.components.media_source import (
     MediaSourceItem,
     PlayMedia,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
@@ -68,7 +69,12 @@ class YotoMediaSource(MediaSource):
     ) -> BrowseMediaSource:
         """Browse media for Yoto."""
         if self.coordinator is None:
-            self.coordinator = next(iter(self.hass.data[DOMAIN].values()))
+            entries = [
+                entry
+                for entry in self.hass.config_entries.async_entries(DOMAIN)
+                if entry.state == ConfigEntryState.LOADED
+            ]
+            self.coordinator = entries[0].runtime_data
         if item.identifier is None:
             return await self.async_convert_library_to_browse_media()
         else:

--- a/custom_components/yoto/number.py
+++ b/custom_components/yoto/number.py
@@ -6,13 +6,13 @@ import logging
 from typing import Final
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from yoto_api import YotoPlayer
 
 from .const import DOMAIN
+from .coordinator import YotoConfigEntry
 from .entity import YotoEntity
 from .utils import rgetattr
 
@@ -61,11 +61,11 @@ SENSOR_DESCRIPTIONS: Final[tuple[NumberEntityDescription, ...]] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: YotoConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up sensor platform."""
-    coordinator = hass.data[DOMAIN][config_entry.unique_id]
+    coordinator = config_entry.runtime_data
     entities: list[YotoNumber] = []
     for player_id in coordinator.yoto_manager.players.keys():
         player: YotoPlayer = coordinator.yoto_manager.players[player_id]

--- a/custom_components/yoto/sensor.py
+++ b/custom_components/yoto/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     LIGHT_LUX,
     PERCENTAGE,
@@ -24,6 +23,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from yoto_api import YotoPlayer
 
 from .const import DOMAIN
+from .coordinator import YotoConfigEntry
 from .entity import YotoEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -81,11 +81,11 @@ SENSOR_DESCRIPTIONS: Final[tuple[YotoSensorEntityDescription, ...]] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: YotoConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up sensor platform."""
-    coordinator = hass.data[DOMAIN][config_entry.unique_id]
+    coordinator = config_entry.runtime_data
     entities: list[YotoSensor] = []
     for player_id in coordinator.yoto_manager.players.keys():
         player: YotoPlayer = coordinator.yoto_manager.players[player_id]

--- a/custom_components/yoto/services.py
+++ b/custom_components/yoto/services.py
@@ -1,9 +1,13 @@
-import logging
-from typing import cast
+"""Yoto integration services."""
 
-from homeassistant.config_entries import ConfigEntry
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry
 
 from .const import DOMAIN
@@ -17,68 +21,41 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @callback
-def async_setup_services(hass: HomeAssistant) -> bool:
-    """Set up services for Yoto"""
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Set up services for Yoto."""
 
     async def async_handle_update(call: ServiceCall) -> None:
         _LOGGER.debug(f"Call:{call.data}")
         coordinator = _get_coordinator_from_device(hass, call)
         await coordinator.async_update_all()
 
-    services: dict[str, object] = {SERVICE_UPDATE: async_handle_update}
+    services = {SERVICE_UPDATE: async_handle_update}
 
     for service in SUPPORTED_SERVICES:
         hass.services.async_register(DOMAIN, service, services[service])
-    return True
-
-
-@callback
-def async_unload_services(hass: HomeAssistant) -> None:
-    for service in SUPPORTED_SERVICES:
-        hass.services.async_remove(DOMAIN, service)
-
-
-def _get_player_id_from_device(hass: HomeAssistant, call: ServiceCall) -> str:
-    """Get player ID from device registry."""
-    coordinators = list(hass.data[DOMAIN].keys())
-    if len(coordinators) == 1:
-        coordinator = hass.data[DOMAIN][coordinators[0]]
-        players = coordinator.yoto_manager.players
-        if len(players) == 1:
-            return list(players.keys())[0]
-
-    device_entry = device_registry.async_get(hass).async_get(call.data[ATTR_DEVICE_ID])
-    for entry in device_entry.identifiers:
-        if entry[0] == DOMAIN:
-            player_id = entry[1]
-    return player_id
 
 
 def _get_coordinator_from_device(
     hass: HomeAssistant, call: ServiceCall
 ) -> YotoDataUpdateCoordinator:
-    """Get coordinator from device registry."""
-    coordinators = list(hass.data[DOMAIN].keys())
-    if len(coordinators) == 1:
-        return hass.data[DOMAIN][coordinators[0]]
-    else:
-        device_entry = device_registry.async_get(hass).async_get(
-            call.data[ATTR_DEVICE_ID]
-        )
-        config_entry_ids = device_entry.config_entries
-        config_entry_id = next(
-            (
-                config_entry_id
-                for config_entry_id in config_entry_ids
-                if cast(
-                    ConfigEntry,
-                    hass.config_entries.async_get_entry(config_entry_id),
-                ).domain
-                == DOMAIN
-            ),
-            None,
-        )
-        config_entry_unique_id = hass.config_entries.async_get_entry(
-            config_entry_id
-        ).unique_id
-        return hass.data[DOMAIN][config_entry_unique_id]
+    """Get the coordinator targeted by the service call."""
+    entries = [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.state == ConfigEntryState.LOADED
+    ]
+    if not entries:
+        raise ServiceValidationError("No loaded Yoto config entry found")
+
+    if len(entries) == 1:
+        return entries[0].runtime_data
+
+    device_entry = device_registry.async_get(hass).async_get(call.data[ATTR_DEVICE_ID])
+    if device_entry is None:
+        raise ServiceValidationError("Device not found")
+
+    for entry in entries:
+        if entry.entry_id in device_entry.config_entries:
+            return entry.runtime_data
+
+    raise ServiceValidationError("No Yoto config entry for the requested device")

--- a/custom_components/yoto/switch.py
+++ b/custom_components/yoto/switch.py
@@ -6,12 +6,12 @@ import logging
 from typing import Final
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from yoto_api import YotoPlayer
 
 from .const import DOMAIN
+from .coordinator import YotoConfigEntry
 from .entity import YotoEntity
 from .utils import parse_key
 
@@ -35,11 +35,11 @@ SENSOR_DESCRIPTIONS: Final[tuple[SwitchEntityDescription, ...]] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: YotoConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up sensor platform."""
-    coordinator = hass.data[DOMAIN][config_entry.unique_id]
+    coordinator = config_entry.runtime_data
     entities: list[YotoSwitch] = []
     for player_id in coordinator.yoto_manager.players.keys():
         player: YotoPlayer = coordinator.yoto_manager.players[player_id]

--- a/custom_components/yoto/time.py
+++ b/custom_components/yoto/time.py
@@ -6,13 +6,12 @@ from datetime import time
 from typing import Final
 
 from homeassistant.components.time import TimeEntity, TimeEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from yoto_api import YotoPlayer
 
 from .const import DOMAIN
-from .coordinator import YotoDataUpdateCoordinator
+from .coordinator import YotoConfigEntry, YotoDataUpdateCoordinator
 from .entity import YotoEntity
 
 TIME_DESCRIPTIONS: Final[tuple[TimeEntityDescription, ...]] = (
@@ -29,11 +28,11 @@ TIME_DESCRIPTIONS: Final[tuple[TimeEntityDescription, ...]] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: YotoConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up time platform."""
-    coordinator = hass.data[DOMAIN][config_entry.unique_id]
+    coordinator = config_entry.runtime_data
     entities: list[YotoTime] = []
     for player_id in coordinator.yoto_manager.players.keys():
         player: YotoPlayer = coordinator.yoto_manager.players[player_id]


### PR DESCRIPTION
Bronze quality scale prep, addressing the `runtime-data` and `action-setup` rules.

The coordinator now lives on `entry.runtime_data` instead of a global `hass.data` dict. This is the modern HA pattern: typed access, no manual setup or pop, and no risk of stale entries leaking between reloads.

Services are also registered at component load instead of per entry, so `yoto.update` stays available even when the only entry is being reloaded.

A few small cleanups came along while touching these files (corrected annotations, dead code removal, stale docstrings).

Changes have been tested with my Yoto Mini.