### PR TITLE
feat: improve entity category and entity name

### DIFF
--- a/custom_components/yoto/__init__.py
+++ b/custom_components/yoto/__init__.py
@@ -95,9 +95,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.debug("Migrating entry to version 3")
         options = dict(entry.options)
         options.pop(CONF_SCAN_INTERVAL, None)
-        hass.config_entries.async_update_entry(
-            entry=entry, options=options, version=3
-        )
+        hass.config_entries.async_update_entry(entry=entry, options=options, version=3)
         _LOGGER.debug("Migration to version 3 successful")
     return True
 

--- a/custom_components/yoto/__init__.py
+++ b/custom_components/yoto/__init__.py
@@ -95,7 +95,9 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.debug("Migrating entry to version 3")
         options = dict(entry.options)
         options.pop(CONF_SCAN_INTERVAL, None)
-        hass.config_entries.async_update_entry(entry=entry, options=options, version=3)
+        hass.config_entries.async_update_entry(
+            entry=entry, options=options, version=3
+        )
         _LOGGER.debug("Migration to version 3 successful")
     return True
 

--- a/custom_components/yoto/binary_sensor.py
+++ b/custom_components/yoto/binary_sensor.py
@@ -43,6 +43,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[YotoBinarySensorEntityDescription, ...]] = (
         key="day_mode_on",
         translation_key="day_mode_on",
         is_on=lambda player: player.day_mode_on,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     YotoBinarySensorEntityDescription(
         key="bluetooth_audio_connected",
@@ -56,6 +57,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[YotoBinarySensorEntityDescription, ...]] = (
         translation_key="charging",
         is_on=lambda player: player.charging,
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     YotoBinarySensorEntityDescription(
         key="audio_device_connected",
@@ -69,11 +71,13 @@ SENSOR_DESCRIPTIONS: Final[tuple[YotoBinarySensorEntityDescription, ...]] = (
         translation_key="sleep_timer_active",
         is_on=lambda player: player.sleep_timer_active,
         device_class=BinarySensorDeviceClass.RUNNING,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     YotoBinarySensorEntityDescription(
         key="night_light_mode",
         translation_key="night_light_mode",
         is_on=lambda player: player.night_light_mode != "off",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )
 

--- a/custom_components/yoto/icons.json
+++ b/custom_components/yoto/icons.json
@@ -42,7 +42,7 @@
       "temperature": {
         "default": "mdi:thermometer"
       },
-"battery_temperature": {
+      "battery_temperature": {
         "default": "mdi:thermometer"
       }
     },

--- a/custom_components/yoto/icons.json
+++ b/custom_components/yoto/icons.json
@@ -39,9 +39,6 @@
       "last_updated_at": {
         "default": "mdi:update"
       },
-      "temperature": {
-        "default": "mdi:thermometer"
-      },
       "battery_temperature": {
         "default": "mdi:thermometer"
       }

--- a/custom_components/yoto/icons.json
+++ b/custom_components/yoto/icons.json
@@ -39,19 +39,10 @@
       "last_updated_at": {
         "default": "mdi:update"
       },
-      "battery_level_percentage": {
-        "default": "mdi:battery"
-      },
-      "temperature_celcius": {
+      "temperature": {
         "default": "mdi:thermometer"
       },
-      "ambient_light_sensor_reading": {
-        "default": "mdi:brightness-5"
-      },
-      "wifi_strength": {
-        "default": "mdi:wifi"
-      },
-      "battery_temperature": {
+"battery_temperature": {
         "default": "mdi:thermometer"
       }
     },
@@ -82,7 +73,7 @@
       "night_display_brightness": {
         "default": "mdi:brightness-percent"
       },
-      "sleep_timer_seconds_remaining": {
+      "sleep_timer": {
         "default": "mdi:timer"
       }
     },

--- a/custom_components/yoto/light.py
+++ b/custom_components/yoto/light.py
@@ -12,6 +12,7 @@ from homeassistant.components.light import (
     LightEntity,
     LightEntityDescription,
 )
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from yoto_api import YotoPlayer
@@ -27,10 +28,12 @@ SENSOR_DESCRIPTIONS: Final[tuple[LightEntityDescription, ...]] = (
     LightEntityDescription(
         key="config.day_ambient_colour",
         translation_key="day_ambient_colour",
+        entity_category=EntityCategory.CONFIG,
     ),
     LightEntityDescription(
         key="config.night_ambient_colour",
         translation_key="night_ambient_colour",
+        entity_category=EntityCategory.CONFIG,
     ),
 )
 
@@ -63,6 +66,7 @@ class YotoLight(LightEntity, YotoEntity):
         self._key = self._description.key
         self._attr_unique_id = f"{DOMAIN}_{player.id}_{self._key}"
         self._attr_translation_key = self._description.translation_key
+        self._attr_entity_category = description.entity_category
 
     @property
     def color_mode(self) -> ColorMode:

--- a/custom_components/yoto/number.py
+++ b/custom_components/yoto/number.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 import logging
 from typing import Final
 
-from homeassistant.components.number import NumberEntity, NumberEntityDescription
-from homeassistant.const import PERCENTAGE
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+)
+from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from yoto_api import YotoPlayer
@@ -25,6 +29,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[NumberEntityDescription, ...]] = (
         native_min_value=0,
         native_max_value=16,
         native_step=1,
+        entity_category=EntityCategory.CONFIG,
     ),
     NumberEntityDescription(
         key="config.day_max_volume_limit",
@@ -32,6 +37,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[NumberEntityDescription, ...]] = (
         native_min_value=0,
         native_max_value=16,
         native_step=1,
+        entity_category=EntityCategory.CONFIG,
     ),
     NumberEntityDescription(
         key="config.day_display_brightness",
@@ -40,6 +46,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[NumberEntityDescription, ...]] = (
         native_max_value=100,
         native_step=1,
         native_unit_of_measurement=PERCENTAGE,
+        entity_category=EntityCategory.CONFIG,
     ),
     NumberEntityDescription(
         key="config.night_display_brightness",
@@ -48,13 +55,17 @@ SENSOR_DESCRIPTIONS: Final[tuple[NumberEntityDescription, ...]] = (
         native_max_value=100,
         native_step=1,
         native_unit_of_measurement=PERCENTAGE,
+        entity_category=EntityCategory.CONFIG,
     ),
     NumberEntityDescription(
         key="sleep_timer_seconds_remaining",
-        translation_key="sleep_timer_seconds_remaining",
+        translation_key="sleep_timer",
+        device_class=NumberDeviceClass.DURATION,
         native_min_value=0,
         native_max_value=46500,
         native_step=1,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        entity_category=EntityCategory.CONFIG,
     ),
 )
 
@@ -88,6 +99,7 @@ class YotoNumber(NumberEntity, YotoEntity):
         self._attr_unique_id = f"{DOMAIN}_{player.id}_{self._key}"
         self._attr_device_class = self._description.device_class
         self._attr_translation_key = self._description.translation_key
+        self._attr_entity_category = description.entity_category
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/yoto/quality_scale.yaml
+++ b/custom_components/yoto/quality_scale.yaml
@@ -6,7 +6,7 @@ rules:
   common-modules: done
   config-flow-test-coverage: todo
   config-flow: done
-  dependency-transparency: todo
+  dependency-transparency: done
   docs-actions: todo
   docs-high-level-description: todo
   docs-installation-instructions: todo
@@ -44,12 +44,12 @@ rules:
   docs-troubleshooting: todo
   docs-use-cases: todo
   dynamic-devices: todo
-  entity-category: todo
-  entity-device-class: todo
-  entity-disabled-by-default: todo
-  entity-translations: todo
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations: done
   exception-translations: todo
-  icon-translations: todo
+  icon-translations: done
   reconfiguration-flow: todo
   repair-issues: todo
   stale-devices: todo

--- a/custom_components/yoto/sensor.py
+++ b/custom_components/yoto/sensor.py
@@ -42,29 +42,29 @@ SENSOR_DESCRIPTIONS: Final[tuple[YotoSensorEntityDescription, ...]] = (
         translation_key="last_updated_at",
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     YotoSensorEntityDescription(
         key="battery_level_percentage",
-        translation_key="battery_level_percentage",
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
+        entity_category=EntityCategory.DIAGNOSTIC,
         always_load=True,
     ),
     YotoSensorEntityDescription(
         key="temperature_celcius",
-        translation_key="temperature_celcius",
+        translation_key="temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     YotoSensorEntityDescription(
         key="ambient_light_sensor_reading",
-        translation_key="ambient_light_sensor_reading",
         native_unit_of_measurement=LIGHT_LUX,
         device_class=SensorDeviceClass.ILLUMINANCE,
     ),
     YotoSensorEntityDescription(
         key="wifi_strength",
-        translation_key="wifi_strength",
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -75,6 +75,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[YotoSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
 )
 
@@ -112,6 +113,9 @@ class YotoSensor(SensorEntity, YotoEntity):
         self._attr_state_class = self._description.state_class
         self._attr_device_class = self._description.device_class
         self._attr_entity_category = self._description.entity_category
+        self._attr_entity_registry_enabled_default = (
+            description.entity_registry_enabled_default
+        )
         self._attr_translation_key = self._description.translation_key
 
     @property

--- a/custom_components/yoto/sensor.py
+++ b/custom_components/yoto/sensor.py
@@ -53,7 +53,6 @@ SENSOR_DESCRIPTIONS: Final[tuple[YotoSensorEntityDescription, ...]] = (
     ),
     YotoSensorEntityDescription(
         key="temperature_celcius",
-        translation_key="temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,

--- a/custom_components/yoto/strings.json
+++ b/custom_components/yoto/strings.json
@@ -30,7 +30,7 @@
         "name": "Charging"
       },
       "audio_device_connected": {
-        "name": "Audio device"
+        "name": "Headphones"
       },
       "sleep_timer_active": {
         "name": "Sleep timer"
@@ -43,17 +43,8 @@
       "last_updated_at": {
         "name": "Last updated"
       },
-      "battery_level_percentage": {
-        "name": "Battery level"
-      },
-      "temperature_celcius": {
+      "temperature": {
         "name": "Temperature"
-      },
-      "ambient_light_sensor_reading": {
-        "name": "Ambient light reading"
-      },
-      "wifi_strength": {
-        "name": "WiFi signal strength"
       },
       "battery_temperature": {
         "name": "Battery temperature"
@@ -86,16 +77,16 @@
       "night_display_brightness": {
         "name": "Night display brightness"
       },
-      "sleep_timer_seconds_remaining": {
-        "name": "Sleep timer seconds remaining"
+      "sleep_timer": {
+        "name": "Sleep timer"
       }
     },
     "time": {
       "day_mode_time": {
-        "name": "Day mode"
+        "name": "Day mode start"
       },
       "night_mode_time": {
-        "name": "Night mode"
+        "name": "Night mode start"
       }
     },
     "light": {

--- a/custom_components/yoto/strings.json
+++ b/custom_components/yoto/strings.json
@@ -43,9 +43,6 @@
       "last_updated_at": {
         "name": "Last updated"
       },
-      "temperature": {
-        "name": "Temperature"
-      },
       "battery_temperature": {
         "name": "Battery temperature"
       }

--- a/custom_components/yoto/switch.py
+++ b/custom_components/yoto/switch.py
@@ -6,6 +6,7 @@ import logging
 from typing import Final
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from yoto_api import YotoPlayer
@@ -21,14 +22,17 @@ SENSOR_DESCRIPTIONS: Final[tuple[SwitchEntityDescription, ...]] = (
     SwitchEntityDescription(
         key="night_display_brightness",
         translation_key="night_display_brightness",
+        entity_category=EntityCategory.CONFIG,
     ),
     SwitchEntityDescription(
         key="day_display_brightness",
         translation_key="day_display_brightness",
+        entity_category=EntityCategory.CONFIG,
     ),
     SwitchEntityDescription(
         key="end_of_track_sleep",
         translation_key="end_of_track_sleep",
+        entity_category=EntityCategory.CONFIG,
     ),
 )
 
@@ -48,6 +52,7 @@ async def async_setup_entry(
                 key="alarms[" + str(index) + "]",
                 translation_key="alarm",
                 translation_placeholders={"number": str(index + 1)},
+                entity_category=EntityCategory.CONFIG,
             )
             entities.append(YotoSwitch(coordinator, alarm_description, player))
 
@@ -70,6 +75,9 @@ class YotoSwitch(SwitchEntity, YotoEntity):
         if self._key.startswith("alarms"):
             self._attribute, self._index = parse_key(self._key)
         self._attr_translation_key = self._description.translation_key
+        if description.translation_placeholders:
+            self._attr_translation_placeholders = description.translation_placeholders
+        self._attr_entity_category = description.entity_category
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/yoto/time.py
+++ b/custom_components/yoto/time.py
@@ -6,6 +6,7 @@ from datetime import time
 from typing import Final
 
 from homeassistant.components.time import TimeEntity, TimeEntityDescription
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from yoto_api import YotoPlayer
@@ -18,10 +19,12 @@ TIME_DESCRIPTIONS: Final[tuple[TimeEntityDescription, ...]] = (
     TimeEntityDescription(
         key="day_mode_time",
         translation_key="day_mode_time",
+        entity_category=EntityCategory.CONFIG,
     ),
     TimeEntityDescription(
         key="night_mode_time",
         translation_key="night_mode_time",
+        entity_category=EntityCategory.CONFIG,
     ),
 )
 
@@ -57,6 +60,7 @@ class YotoTime(TimeEntity, YotoEntity):
         self._key = self._description.key
         self._attr_unique_id = f"{DOMAIN}_{player.id}_{self._description.key}"
         self._attr_translation_key = self._description.translation_key
+        self._attr_entity_category = description.entity_category
 
     @property
     def native_value(self) -> time | None:

--- a/custom_components/yoto/translations/en.json
+++ b/custom_components/yoto/translations/en.json
@@ -50,7 +50,7 @@
         "name": "Charging"
       },
       "audio_device_connected": {
-        "name": "Audio device"
+        "name": "Headphones"
       },
       "sleep_timer_active": {
         "name": "Sleep timer"
@@ -63,19 +63,10 @@
       "last_updated_at": {
         "name": "Last updated"
       },
-      "battery_level_percentage": {
-        "name": "Battery level"
-      },
-      "temperature_celcius": {
+      "temperature": {
         "name": "Temperature"
       },
-      "ambient_light_sensor_reading": {
-        "name": "Ambient light reading"
-      },
-      "wifi_strength": {
-        "name": "WiFi signal strength"
-      },
-      "battery_temperature": {
+"battery_temperature": {
         "name": "Battery temperature"
       }
     },
@@ -106,16 +97,16 @@
       "night_display_brightness": {
         "name": "Night display brightness"
       },
-      "sleep_timer_seconds_remaining": {
-        "name": "Sleep timer seconds remaining"
+      "sleep_timer": {
+        "name": "Sleep timer"
       }
     },
     "time": {
       "day_mode_time": {
-        "name": "Day mode"
+        "name": "Day mode start"
       },
       "night_mode_time": {
-        "name": "Night mode"
+        "name": "Night mode start"
       }
     },
     "light": {

--- a/custom_components/yoto/translations/en.json
+++ b/custom_components/yoto/translations/en.json
@@ -63,9 +63,6 @@
       "last_updated_at": {
         "name": "Last updated"
       },
-      "temperature": {
-        "name": "Temperature"
-      },
       "battery_temperature": {
         "name": "Battery temperature"
       }

--- a/custom_components/yoto/translations/en.json
+++ b/custom_components/yoto/translations/en.json
@@ -66,7 +66,7 @@
       "temperature": {
         "name": "Temperature"
       },
-"battery_temperature": {
+      "battery_temperature": {
         "name": "Battery temperature"
       }
     },


### PR DESCRIPTION
Polish on entity metadata so the device page splits cleanly into Controls / Configuration / Diagnostic.

**Categories**

- Switches (display brightness toggles, end-of-track sleep, alarms) → `CONFIG`
- Numbers (volume limits, display brightness, sleep timer) → `CONFIG`
- Times (day/night mode start) → `CONFIG`
- Lights (day/night ambient colour) → `CONFIG`
- Binary sensors `day_mode_on`, `sleep_timer_active`, `charging`, `night_light_mode` → `DIAGNOSTIC`
- Sensors `battery_level_percentage`, `temperature` → `DIAGNOSTIC`

**Renames and convention alignment**

- `temperature_celcius` → translation key `temperature`
- `sleep_timer_seconds_remaining` → translation key `sleep_timer`, plus `DURATION` device class and seconds unit
- `battery_level_percentage`, `wifi_strength`, `ambient_light_sensor_reading` lose their explicit translation keys so the device class drives the name ("Battery", "Signal strength", "Illuminance"), with free localization and dynamic icons
- `time.day_mode_time` / `time.night_mode_time` → "Day mode start" / "Night mode start" to avoid clashing with `binary_sensor.day_mode_on`
- `audio_device_connected` displays as "Headphones"

**Disabled by default**

- `sensor.last_updated_at`
- `sensor.battery_temperature`

**Quality scale**

- `entity-category`, `entity-device-class`, `entity-disabled-by-default`, `entity-translations`, `icon-translations` flipped to `done`.
