### PR TITLE
fix: update yoto-api to 2.3.0 and use new playback controls

### DIFF
--- a/custom_components/yoto/coordinator.py
+++ b/custom_components/yoto/coordinator.py
@@ -184,6 +184,27 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
             trackkey,
         )
 
+    async def async_seek(self, player_id: str, position: int) -> None:
+        """Seek to a position in the current track."""
+        await self.async_check_and_refresh_token()
+        await self.hass.async_add_executor_job(
+            self.yoto_manager.seek, player_id, position
+        )
+
+    async def async_next_track(self, player_id: str) -> None:
+        """Skip to the next track."""
+        await self.async_check_and_refresh_token()
+        await self.hass.async_add_executor_job(
+            self.yoto_manager.next_track, player_id
+        )
+
+    async def async_previous_track(self, player_id: str) -> None:
+        """Skip to the previous track."""
+        await self.async_check_and_refresh_token()
+        await self.hass.async_add_executor_job(
+            self.yoto_manager.previous_track, player_id
+        )
+
     async def async_set_volume(self, player_id: str, volume: float) -> None:
         """Set player volume level."""
         volume = volume * 100

--- a/custom_components/yoto/coordinator.py
+++ b/custom_components/yoto/coordinator.py
@@ -194,9 +194,7 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
     async def async_next_track(self, player_id: str) -> None:
         """Skip to the next track."""
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
-            self.yoto_manager.next_track, player_id
-        )
+        await self.hass.async_add_executor_job(self.yoto_manager.next_track, player_id)
 
     async def async_previous_track(self, player_id: str) -> None:
         """Skip to the previous track."""

--- a/custom_components/yoto/manifest.json
+++ b/custom_components/yoto/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/cdnninja/yoto_ha/issues",
   "loggers": ["yoto", "yoto_api", "paho_mqtt"],
-  "requirements": ["yoto-api==2.2.6"],
+  "requirements": ["yoto-api==2.3.0"],
   "version": "3.2.0"
 }

--- a/custom_components/yoto/media_player.py
+++ b/custom_components/yoto/media_player.py
@@ -81,25 +81,11 @@ class YotoMediaPlayer(MediaPlayerEntity, YotoEntity):
 
     async def async_media_next_track(self) -> None:
         """Skip to next track."""
-        cardid, chapterid, trackid, time = split_media_id(self.media_content_id)
-        if chapterid:
-            chapterid = int(chapterid) + 1
-        if trackid:
-            trackid = int(trackid) + 1
-        await self.coordinator.async_play_card(
-            player_id=self.player.id, cardid=cardid, chapter=chapterid, trackkey=trackid
-        )
+        await self.coordinator.async_next_track(self.player.id)
 
     async def async_media_previous_track(self) -> None:
         """Skip to previous track."""
-        cardid, chapterid, trackid, time = split_media_id(self.media_content_id)
-        if chapterid:
-            chapterid = int(chapterid) - 1
-        if trackid:
-            trackid = int(trackid) - 1
-        await self.coordinator.async_play_card(
-            player_id=self.player.id, cardid=cardid, chapter=chapterid, trackkey=trackid
-        )
+        await self.coordinator.async_previous_track(self.player.id)
 
     async def async_play_media(
         self,
@@ -124,13 +110,7 @@ class YotoMediaPlayer(MediaPlayerEntity, YotoEntity):
 
     async def async_media_seek(self, position: float) -> None:
         """Send seek command."""
-        await self.coordinator.async_play_card(
-            player_id=self.player.id,
-            cardid=self.player.card_id,
-            chapter=self.player.chapter_key,
-            trackkey=self.player.track_key,
-            secondsin=int(position),
-        )
+        await self.coordinator.async_seek(self.player.id, int(position))
 
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level."""


### PR DESCRIPTION
Bumps `yoto-api` from 2.2.6 to 2.3.0.

Skip and seek now use the new helpers in the library, which fixes a few longstanding quirks: skipping across chapter boundaries works, and skipping past the start or end of a card no longer sends an invalid command.

The bump also pulls in fixes from 2.2.7 to 2.2.9: volume no longer flickers when the player reports both data and status, and accounts with more than one consumer connected at once stop fighting over the same MQTT client ID.

Changes have been tested with my Yoto Mini.
