### PR TITLE
refactor: migrate to yoto-api 3.0 typed client

### DIFF
--- a/custom_components/yoto/__init__.py
+++ b/custom_components/yoto/__init__.py
@@ -54,7 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: YotoConfigEntry) 
 
     async def _handle_shutdown(event):
         new_data = dict(config_entry.data)
-        new_data[CONF_TOKEN] = coordinator.yoto_manager.token.refresh_token
+        new_data[CONF_TOKEN] = coordinator.yoto_client.token.refresh_token
         _LOGGER.debug("Storing token on HA shutdown.")
         hass.config_entries.async_update_entry(config_entry, data=new_data)
 
@@ -71,9 +71,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: YotoConfigEntry) 
 async def async_unload_entry(hass: HomeAssistant, entry: YotoConfigEntry) -> bool:
     """Handle removal of an entry."""
     coordinator = entry.runtime_data
-    if coordinator.yoto_manager.token.refresh_token != entry.data.get(CONF_TOKEN):
+    if coordinator.yoto_client.token.refresh_token != entry.data.get(CONF_TOKEN):
         new_data = dict(entry.data)
-        new_data[CONF_TOKEN] = coordinator.yoto_manager.token.refresh_token
+        new_data[CONF_TOKEN] = coordinator.yoto_client.token.refresh_token
         _LOGGER.debug("Storing token on unload")
         hass.config_entries.async_update_entry(entry, data=new_data)
 

--- a/custom_components/yoto/__init__.py
+++ b/custom_components/yoto/__init__.py
@@ -1,6 +1,5 @@
 """Yoto integration."""
 
-import asyncio
 import logging
 
 from homeassistant.config_entries import ConfigEntry
@@ -45,12 +44,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: YotoConfigEntry) 
     coordinator = YotoDataUpdateCoordinator(hass, config_entry)
     try:
         await coordinator.async_config_entry_first_refresh()
-        await asyncio.sleep(3)
     except AuthenticationError as ex:
         _LOGGER.error(f"Authentication error: {ex}")
         raise ConfigEntryAuthFailed from ex
 
     config_entry.runtime_data = coordinator
+    coordinator.setup_periodic_status_push()
 
     async def _handle_shutdown(event):
         new_data = dict(config_entry.data)

--- a/custom_components/yoto/binary_sensor.py
+++ b/custom_components/yoto/binary_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from yoto_api import YotoPlayer
+from yoto_api import DayMode, YotoPlayer, caps_for
 
 from .const import DOMAIN
 from .coordinator import YotoConfigEntry, YotoDataUpdateCoordinator
@@ -28,55 +28,69 @@ _LOGGER = logging.getLogger(__name__)
 class YotoBinarySensorEntityDescription(BinarySensorEntityDescription):
     """A class that describes custom binary sensor entities."""
 
-    is_on: Callable[[YotoPlayer], bool] | None = None
+    value: Callable[[YotoPlayer], bool | None] | None = None
+    requires_ambient_light: bool = False
+
+
+def _day_mode_on(player: YotoPlayer) -> bool | None:
+    day_mode = player.status.day_mode
+    if day_mode is None or day_mode == DayMode.UNKNOWN:
+        return None
+    return day_mode == DayMode.DAY
+
+
+def _night_light_on(player: YotoPlayer) -> bool | None:
+    mode = player.status.nightlight_mode
+    return None if mode is None else mode != "off"
 
 
 SENSOR_DESCRIPTIONS: Final[tuple[YotoBinarySensorEntityDescription, ...]] = (
     YotoBinarySensorEntityDescription(
         key="online",
         translation_key="online",
-        is_on=lambda player: player.online,
+        value=lambda player: player.status.is_online,
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     YotoBinarySensorEntityDescription(
         key="day_mode_on",
         translation_key="day_mode_on",
-        is_on=lambda player: player.day_mode_on,
+        value=_day_mode_on,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     YotoBinarySensorEntityDescription(
         key="bluetooth_audio_connected",
         translation_key="bluetooth_audio_connected",
-        is_on=lambda player: player.bluetooth_audio_connected,
+        value=lambda player: player.status.is_bluetooth_audio_connected,
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     YotoBinarySensorEntityDescription(
         key="charging",
         translation_key="charging",
-        is_on=lambda player: player.charging,
+        value=lambda player: player.status.is_charging,
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     YotoBinarySensorEntityDescription(
         key="audio_device_connected",
         translation_key="audio_device_connected",
-        is_on=lambda player: player.audio_device_connected,
+        value=lambda player: player.status.is_audio_device_connected,
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     YotoBinarySensorEntityDescription(
         key="sleep_timer_active",
         translation_key="sleep_timer_active",
-        is_on=lambda player: player.sleep_timer_active,
+        value=lambda player: bool(player.last_event.sleep_timer_active),
         device_class=BinarySensorDeviceClass.RUNNING,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     YotoBinarySensorEntityDescription(
         key="night_light_mode",
         translation_key="night_light_mode",
-        is_on=lambda player: player.night_light_mode != "off",
+        value=_night_light_on,
+        requires_ambient_light=True,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )
@@ -90,16 +104,21 @@ async def async_setup_entry(
     """Set up binary_sensor platform."""
     coordinator = config_entry.runtime_data
     entities: list[YotoBinarySensor] = []
-    for player_id in coordinator.yoto_manager.players.keys():
-        player: YotoPlayer = coordinator.yoto_manager.players[player_id]
+    for player_id in coordinator.yoto_client.players.keys():
+        player: YotoPlayer = coordinator.yoto_client.players[player_id]
+        caps = caps_for(player.device)
         for description in SENSOR_DESCRIPTIONS:
-            if getattr(player, description.key, None) is not None:
+            if description.requires_ambient_light and not caps.has_ambient_light:
+                continue
+            if description.value is not None and description.value(player) is not None:
                 entities.append(YotoBinarySensor(coordinator, description, player))
     async_add_entities(entities)
 
 
 class YotoBinarySensor(BinarySensorEntity, YotoEntity):
     """Yoto binary sensor class."""
+
+    entity_description: YotoBinarySensorEntityDescription
 
     def __init__(
         self,
@@ -109,15 +128,11 @@ class YotoBinarySensor(BinarySensorEntity, YotoEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, player)
-        self._description = description
-        self._attr_unique_id = f"{DOMAIN}_{player.id}_{self._description.key}"
-        self._attr_device_class = self._description.device_class
-        self._attr_entity_category = self._description.entity_category
-        self._attr_translation_key = self._description.translation_key
+        self.entity_description = description
+        self._attr_unique_id = f"{DOMAIN}_{player.id}_{description.key}"
 
     @property
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
-        if self._description.is_on is not None:
-            return self._description.is_on(self.player)
-        return None
+        value = self.entity_description.value
+        return value(self.player) if value is not None else None

--- a/custom_components/yoto/config_flow.py
+++ b/custom_components/yoto/config_flow.py
@@ -10,6 +10,7 @@ from typing import Any
 from homeassistant import config_entries
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from yoto_api import YotoClient
 
 from .const import CONF_TOKEN, DOMAIN
@@ -47,27 +48,25 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if self.ym is None:
             _LOGGER.debug("Initiating device activation")
-            self.ym = await self.hass.async_add_executor_job(
-                YotoClient, "KFLTf5PCpTh0yOuDuyQ5C3LEU9PSbult"
+            self.ym = YotoClient(
+                client_id="KFLTf5PCpTh0yOuDuyQ5C3LEU9PSbult",
+                session=async_get_clientsession(self.hass),
             )
-            assert self.ym is not None
-            urlObject = await self.hass.async_add_executor_job(
-                self.ym.device_code_flow_start
-            )
+            urlObject = await self.ym.device_code_flow_start()
             yoto_device_url = urlObject["verification_uri_complete"]
 
         async def _wait_for_login() -> None:
             """Wait for the user to login and validate the resulting token."""
             assert self.ym is not None
             _LOGGER.debug("Waiting for device activation")
-            await self.hass.async_add_executor_job(self.ym.device_code_flow_complete)
+            await self.ym.device_code_flow_complete()
 
             if self.ym.token is None:
                 raise HomeAssistantError("Device activation failed")
 
             # Validate the token by hitting the players endpoint. Surfaces a
             # bad/expired token before the entry is created.
-            await self.hass.async_add_executor_job(self.ym.update_player_list)
+            await self.ym.update_player_list()
             if not self.ym.players:
                 raise HomeAssistantError("No Yoto players found on this account")
 

--- a/custom_components/yoto/config_flow.py
+++ b/custom_components/yoto/config_flow.py
@@ -10,7 +10,7 @@ from typing import Any
 from homeassistant import config_entries
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
 from homeassistant.exceptions import HomeAssistantError
-from yoto_api import YotoManager
+from yoto_api import YotoClient
 
 from .const import CONF_TOKEN, DOMAIN
 
@@ -23,7 +23,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 3
     login_task: asyncio.Task | None = None
     token = None
-    ym: YotoManager | None = None
+    ym: YotoClient | None = None
 
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]
@@ -48,7 +48,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if self.ym is None:
             _LOGGER.debug("Initiating device activation")
             self.ym = await self.hass.async_add_executor_job(
-                YotoManager, "KFLTf5PCpTh0yOuDuyQ5C3LEU9PSbult"
+                YotoClient, "KFLTf5PCpTh0yOuDuyQ5C3LEU9PSbult"
             )
             assert self.ym is not None
             urlObject = await self.hass.async_add_executor_job(
@@ -67,7 +67,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             # Validate the token by hitting the players endpoint. Surfaces a
             # bad/expired token before the entry is created.
-            await self.hass.async_add_executor_job(self.ym.update_players_status)
+            await self.hass.async_add_executor_job(self.ym.update_player_list)
             if not self.ym.players:
                 raise HomeAssistantError("No Yoto players found on this account")
 

--- a/custom_components/yoto/const.py
+++ b/custom_components/yoto/const.py
@@ -8,6 +8,12 @@ DOMAIN: str = "yoto"
 # disconnect event, so polling is what surfaces the online -> offline transition.
 SCAN_INTERVAL = timedelta(minutes=5)
 
+# Yoto only emits a `data/status` MQTT message in response to a
+# `command/status/request` publish. The lib fires one on connect and after
+# writes; this heartbeat refreshes MQTT-only fields (battery, charging,
+# brightness, ambient sensor...) between user actions.
+STATUS_PUSH_INTERVAL = timedelta(seconds=60)
+
 DYNAMIC_UNIT: str = "dynamic_unit"
 
 CONF_TOKEN = "token"

--- a/custom_components/yoto/coordinator.py
+++ b/custom_components/yoto/coordinator.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
+from datetime import datetime
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from yoto_api import AuthenticationError, YotoClient
+from yoto_api import AuthenticationError, YotoClient, YotoError
 
-from .const import CONF_TOKEN, DOMAIN, SCAN_INTERVAL
+from .const import CONF_TOKEN, DOMAIN, SCAN_INTERVAL, STATUS_PUSH_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,6 +29,7 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
         self.platforms: set[str] = set()
         self.config_entry = config_entry
         self.yoto_client = YotoClient(client_id="KFLTf5PCpTh0yOuDuyQ5C3LEU9PSbult")
+        self._status_push_unsub: Callable[[], None] | None = None
         if config_entry.data.get(CONF_TOKEN):
             _LOGGER.debug("Using stored token")
             self.yoto_client.set_refresh_token(config_entry.data.get(CONF_TOKEN))
@@ -37,6 +41,30 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
             name=DOMAIN,
             update_interval=SCAN_INTERVAL,
         )
+
+    @callback
+    def setup_periodic_status_push(self) -> None:
+        """Start the MQTT status push heartbeat once MQTT is connected."""
+        if self._status_push_unsub is not None:
+            return
+        self._status_push_unsub = async_track_time_interval(
+            self.hass, self._async_request_status_push, STATUS_PUSH_INTERVAL
+        )
+
+    async def _async_request_status_push(self, _now: datetime) -> None:
+        """Ask every connected player to push its current status over MQTT."""
+        if not self.yoto_client.is_mqtt_connected:
+            return
+        for player_id in list(self.yoto_client.players):
+            try:
+                await self.hass.async_add_executor_job(
+                    self.yoto_client.request_status_push, player_id
+                )
+            except YotoError as err:
+                _LOGGER.debug(
+                    "%s - request_status_push failed for %s: %s",
+                    DOMAIN, player_id, err,
+                )
 
     async def _async_update_data(self) -> dict | None:
         """Update data via library. Called by update_coordinator periodically."""
@@ -85,6 +113,9 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def release(self) -> None:
         """Disconnect from API."""
+        if self._status_push_unsub is not None:
+            self._status_push_unsub()
+            self._status_push_unsub = None
         await self.hass.async_add_executor_job(self.yoto_client.disconnect_events)
 
     async def async_update_all(self) -> None:

--- a/custom_components/yoto/coordinator.py
+++ b/custom_components/yoto/coordinator.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import logging
-from datetime import time
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from yoto_api import AuthenticationError, YotoManager, YotoPlayerConfig
+from yoto_api import AuthenticationError, YotoClient
 
 from .const import CONF_TOKEN, DOMAIN, SCAN_INTERVAL
 
@@ -25,10 +25,10 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
         """Initialize."""
         self.platforms: set[str] = set()
         self.config_entry = config_entry
-        self.yoto_manager = YotoManager(client_id="KFLTf5PCpTh0yOuDuyQ5C3LEU9PSbult")
+        self.yoto_client = YotoClient(client_id="KFLTf5PCpTh0yOuDuyQ5C3LEU9PSbult")
         if config_entry.data.get(CONF_TOKEN):
             _LOGGER.debug("Using stored token")
-            self.yoto_manager.set_refresh_token(config_entry.data.get(CONF_TOKEN))
+            self.yoto_client.set_refresh_token(config_entry.data.get(CONF_TOKEN))
         else:
             raise ConfigEntryAuthFailed("No token configured")
         super().__init__(
@@ -39,18 +39,14 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
         )
 
     async def _async_update_data(self) -> dict | None:
-        """Update data via library. Called by update_coordinator periodically.
-
-        Allow to update for the first time without further checking
-        """
-
+        """Update data via library. Called by update_coordinator periodically."""
         try:
             await self.async_check_and_refresh_token()
-            if self.yoto_manager.token.refresh_token != self.config_entry.data.get(
+            if self.yoto_client.token.refresh_token != self.config_entry.data.get(
                 CONF_TOKEN
             ):
                 new_data = dict(self.config_entry.data)
-                new_data[CONF_TOKEN] = self.yoto_manager.token.refresh_token
+                new_data[CONF_TOKEN] = self.yoto_client.token.refresh_token
                 _LOGGER.debug("Storing updated token")
                 self.hass.config_entries.async_update_entry(
                     self.config_entry, data=new_data
@@ -59,35 +55,37 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.error(f"Authentication error: {ex}")
             raise ConfigEntryAuthFailed
 
-        await self.hass.async_add_executor_job(self.yoto_manager.update_players_status)
-        if len(self.yoto_manager.library.keys()) == 0:
-            await self.hass.async_add_executor_job(self.yoto_manager.update_library)
-        if self.yoto_manager.mqtt_client is None:
+        await self.hass.async_add_executor_job(self.yoto_client.refresh)
+        for player_id in list(self.yoto_client.players):
             await self.hass.async_add_executor_job(
-                self.yoto_manager.connect_to_events, self.api_callback
+                self.yoto_client.update_player_status, player_id
+            )
+        if len(self.yoto_client.library.keys()) == 0:
+            await self.hass.async_add_executor_job(self.yoto_client.update_library)
+        if not self.yoto_client.is_mqtt_connected:
+            await self.hass.async_add_executor_job(
+                self.yoto_client.connect_events,
+                list(self.yoto_client.players),
+                self.api_callback,
             )
         return self.data
 
-    def api_callback(self) -> None:
-        """Handle API callback for media player updates."""
-        for player in self.yoto_manager.players.values():
-            if player.card_id and player.chapter_key:
-                if (
-                    player.card_id not in self.yoto_manager.library
-                    or not self.yoto_manager.library[player.card_id].chapters
-                ):
-                    self.hass.add_job(self.async_update_card_detail, player.card_id)
-                else:
-                    if (
-                        player.chapter_key
-                        not in self.yoto_manager.library[player.card_id].chapters
-                    ):
-                        self.hass.add_job(self.async_update_card_detail, player.card_id)
+    def api_callback(self, player) -> None:
+        """Handle MQTT updates from the library."""
+        event = player.last_event
+        if event.card_id and event.chapter_key:
+            card = self.yoto_client.library.get(event.card_id)
+            if (
+                card is None
+                or not card.chapters
+                or event.chapter_key not in card.chapters
+            ):
+                self.hass.add_job(self.async_update_card_detail, event.card_id)
         self.async_update_listeners()
 
     async def release(self) -> None:
         """Disconnect from API."""
-        self.yoto_manager.disconnect()
+        await self.hass.async_add_executor_job(self.yoto_client.disconnect_events)
 
     async def async_update_all(self) -> None:
         """Update yoto data."""
@@ -96,72 +94,39 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
     async def async_check_and_refresh_token(self) -> None:
         """Refresh token if needed via library."""
         await self.hass.async_add_executor_job(
-            self.yoto_manager.check_and_refresh_token
+            self.yoto_client.check_and_refresh_token
         )
 
     async def async_pause_player(self, player_id: str) -> None:
         """Pause playback on the player."""
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
-            self.yoto_manager.pause_player, player_id
-        )
+        await self.hass.async_add_executor_job(self.yoto_client.pause, player_id)
 
     async def async_resume_player(self, player_id: str) -> None:
         """Resume playback on the player."""
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
-            self.yoto_manager.resume_player, player_id
-        )
+        await self.hass.async_add_executor_job(self.yoto_client.resume, player_id)
 
     async def async_stop_player(self, player_id: str) -> None:
         """Stop playback on the player."""
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(self.yoto_manager.stop_player, player_id)
+        await self.hass.async_add_executor_job(self.yoto_client.stop, player_id)
 
-    async def async_set_time(self, player_id: str, key: str, value: time) -> None:
-        """Set time for day/night mode."""
+    async def async_set_player_config(
+        self, player_id: str, **fields: Any
+    ) -> None:
+        """Update PlayerConfig fields on the device. Pass v3 field names."""
         await self.async_check_and_refresh_token()
-        config = YotoPlayerConfig()
-        if key == "day_mode_time":
-            config.day_mode_time = value
-        if key == "night_mode_time":
-            config.night_mode_time = value
         await self.hass.async_add_executor_job(
-            self.yoto_manager.set_player_config, player_id, config
+            lambda: self.yoto_client.set_player_config(player_id, **fields)
         )
-
-    async def async_set_max_volume(self, player_id: str, key: str, value: int) -> None:
-        """Set maximum volume for day/night mode."""
-        await self.async_check_and_refresh_token()
-        config = YotoPlayerConfig()
-        if key == "config.night_max_volume_limit":
-            config.night_max_volume_limit = int(value)
-        if key == "config.day_max_volume_limit":
-            config.day_max_volume_limit = int(value)
+        # The lib doesn't mirror PlayerConfig writes back onto the local
+        # player.info.config, so refetch /config to surface the new value
+        # before the next 5-minute poll tick.
         await self.hass.async_add_executor_job(
-            self.yoto_manager.set_player_config, player_id, config
+            self.yoto_client.update_player_info, player_id
         )
-
-    async def async_set_brightness(self, player_id: str, key: str, value: str) -> None:
-        """Set display brightness for day/night mode."""
-        await self.async_check_and_refresh_token()
-        config = YotoPlayerConfig()
-        if (
-            key == "config.night_display_brightness"
-            or key == "night_display_brightness"
-        ):
-            if value == "auto":
-                config.night_display_brightness = value
-            else:
-                config.night_display_brightness = int(value)
-        if key == "config.day_display_brightness" or key == "day_display_brightness":
-            if value == "auto":
-                config.day_display_brightness = value
-            else:
-                config.day_display_brightness = int(value)
-        await self.hass.async_add_executor_job(
-            self.yoto_manager.set_player_config, player_id, config
-        )
+        self.async_update_listeners()
 
     async def async_play_card(
         self,
@@ -175,60 +140,50 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
         """Play a card on the player."""
         await self.async_check_and_refresh_token()
         await self.hass.async_add_executor_job(
-            self.yoto_manager.play_card,
-            player_id,
-            cardid,
-            secondsin,
-            cutoff,
-            chapter,
-            trackkey,
+            lambda: self.yoto_client.play_card(
+                player_id,
+                cardid,
+                seconds_in=secondsin,
+                cutoff=cutoff,
+                chapter_key=str(chapter) if chapter is not None else None,
+                track_key=str(trackkey) if trackkey is not None else None,
+            )
         )
 
     async def async_seek(self, player_id: str, position: int) -> None:
         """Seek to a position in the current track."""
         await self.async_check_and_refresh_token()
         await self.hass.async_add_executor_job(
-            self.yoto_manager.seek, player_id, position
+            self.yoto_client.seek, player_id, position
         )
 
     async def async_next_track(self, player_id: str) -> None:
         """Skip to the next track."""
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(self.yoto_manager.next_track, player_id)
+        await self.hass.async_add_executor_job(
+            self.yoto_client.next_track, player_id
+        )
 
     async def async_previous_track(self, player_id: str) -> None:
         """Skip to the previous track."""
         await self.async_check_and_refresh_token()
         await self.hass.async_add_executor_job(
-            self.yoto_manager.previous_track, player_id
+            self.yoto_client.previous_track, player_id
         )
 
     async def async_set_volume(self, player_id: str, volume: float) -> None:
         """Set player volume level."""
-        volume = volume * 100
-        volume = int(round(volume, 0))
+        volume = int(round(volume * 100, 0))
         await self.async_check_and_refresh_token()
         await self.hass.async_add_executor_job(
-            self.yoto_manager.set_volume, player_id, volume
+            self.yoto_client.set_volume, player_id, volume
         )
 
     async def async_set_sleep_timer(self, player_id: str, time: int) -> None:
         """Set sleep timer on the player."""
         await self.async_check_and_refresh_token()
         await self.hass.async_add_executor_job(
-            self.yoto_manager.set_sleep, player_id, int(time)
-        )
-
-    async def async_set_light(self, player_id: str, key: str, color: str) -> None:
-        """Set light color for day/night ambient mode."""
-        await self.async_check_and_refresh_token()
-        config = YotoPlayerConfig()
-        if key == "config.day_ambient_colour":
-            config.day_ambient_colour = color
-        elif key == "config.night_ambient_colour":
-            config.night_ambient_colour = color
-        await self.hass.async_add_executor_job(
-            self.yoto_manager.set_player_config, player_id, config
+            self.yoto_client.set_sleep_timer, player_id, int(time)
         )
 
     async def async_enable_disable_alarm(
@@ -236,21 +191,18 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
     ) -> None:
         """Enable or disable an alarm."""
         await self.async_check_and_refresh_token()
-        config = YotoPlayerConfig()
-        config.alarms = self.yoto_manager.players[player_id].config.alarms
-        config.alarms[alarm].enabled = enable
         await self.hass.async_add_executor_job(
-            self.yoto_manager.set_player_config, player_id, config
+            self.yoto_client.set_alarm_enabled, player_id, alarm, enable
         )
 
     async def async_update_card_detail(self, cardId: str) -> None:
         """Get chapter and titles for the card"""
         _LOGGER.debug(f"{DOMAIN} - Updating Card details for:  {cardId}")
         await self.hass.async_add_executor_job(
-            self.yoto_manager.update_card_detail, cardId
+            self.yoto_client.update_card_detail, cardId
         )
 
     async def async_update_library(self) -> None:
         """Update library details."""
         _LOGGER.debug(f"{DOMAIN} - Updating library details")
-        await self.hass.async_add_executor_job(self.yoto_manager.update_library)
+        await self.hass.async_add_executor_job(self.yoto_client.update_library)

--- a/custom_components/yoto/coordinator.py
+++ b/custom_components/yoto/coordinator.py
@@ -93,9 +93,7 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_check_and_refresh_token(self) -> None:
         """Refresh token if needed via library."""
-        await self.hass.async_add_executor_job(
-            self.yoto_client.check_and_refresh_token
-        )
+        await self.hass.async_add_executor_job(self.yoto_client.check_and_refresh_token)
 
     async def async_pause_player(self, player_id: str) -> None:
         """Pause playback on the player."""
@@ -112,9 +110,7 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
         await self.async_check_and_refresh_token()
         await self.hass.async_add_executor_job(self.yoto_client.stop, player_id)
 
-    async def async_set_player_config(
-        self, player_id: str, **fields: Any
-    ) -> None:
+    async def async_set_player_config(self, player_id: str, **fields: Any) -> None:
         """Update PlayerConfig fields on the device. Pass v3 field names."""
         await self.async_check_and_refresh_token()
         await self.hass.async_add_executor_job(
@@ -160,9 +156,7 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
     async def async_next_track(self, player_id: str) -> None:
         """Skip to the next track."""
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
-            self.yoto_client.next_track, player_id
-        )
+        await self.hass.async_add_executor_job(self.yoto_client.next_track, player_id)
 
     async def async_previous_track(self, player_id: str) -> None:
         """Skip to the previous track."""

--- a/custom_components/yoto/coordinator.py
+++ b/custom_components/yoto/coordinator.py
@@ -10,9 +10,10 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from yoto_api import AuthenticationError, YotoClient, YotoError
+from yoto_api import AuthenticationError, YotoClient, YotoError, YotoPlayer
 
 from .const import CONF_TOKEN, DOMAIN, SCAN_INTERVAL, STATUS_PUSH_INTERVAL
 
@@ -28,7 +29,10 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
         """Initialize."""
         self.platforms: set[str] = set()
         self.config_entry = config_entry
-        self.yoto_client = YotoClient(client_id="KFLTf5PCpTh0yOuDuyQ5C3LEU9PSbult")
+        self.yoto_client = YotoClient(
+            client_id="KFLTf5PCpTh0yOuDuyQ5C3LEU9PSbult",
+            session=async_get_clientsession(hass),
+        )
         self._status_push_unsub: Callable[[], None] | None = None
         if config_entry.data.get(CONF_TOKEN):
             _LOGGER.debug("Using stored token")
@@ -57,9 +61,7 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
             return
         for player_id in list(self.yoto_client.players):
             try:
-                await self.hass.async_add_executor_job(
-                    self.yoto_client.request_status_push, player_id
-                )
+                await self.yoto_client.request_status_push(player_id)
             except YotoError as err:
                 _LOGGER.debug(
                     "%s - request_status_push failed for %s: %s",
@@ -85,22 +87,20 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.error(f"Authentication error: {ex}")
             raise ConfigEntryAuthFailed
 
-        await self.hass.async_add_executor_job(self.yoto_client.refresh)
+        await self.yoto_client.refresh()
         for player_id in list(self.yoto_client.players):
-            await self.hass.async_add_executor_job(
-                self.yoto_client.update_player_status, player_id
-            )
+            await self.yoto_client.update_player_status(player_id)
         if len(self.yoto_client.library.keys()) == 0:
-            await self.hass.async_add_executor_job(self.yoto_client.update_library)
+            await self.yoto_client.update_library()
         if not self.yoto_client.is_mqtt_connected:
-            await self.hass.async_add_executor_job(
-                self.yoto_client.connect_events,
+            await self.yoto_client.connect_events(
                 list(self.yoto_client.players),
-                self.api_callback,
+                on_update=self.api_callback,
             )
         return self.data
 
-    def api_callback(self, player) -> None:
+    @callback
+    def api_callback(self, player: YotoPlayer) -> None:
         """Handle MQTT updates from the library."""
         event = player.last_event
         if event.card_id and event.chapter_key:
@@ -110,7 +110,9 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
                 or not card.chapters
                 or event.chapter_key not in card.chapters
             ):
-                self.hass.add_job(self.async_update_card_detail, event.card_id)
+                self.hass.async_create_task(
+                    self.async_update_card_detail(event.card_id)
+                )
         self.async_update_listeners()
 
     async def release(self) -> None:
@@ -118,7 +120,7 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
         if self._status_push_unsub is not None:
             self._status_push_unsub()
             self._status_push_unsub = None
-        await self.hass.async_add_executor_job(self.yoto_client.disconnect_events)
+        await self.yoto_client.disconnect_events()
 
     async def async_update_all(self) -> None:
         """Update yoto data."""
@@ -126,35 +128,31 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_check_and_refresh_token(self) -> None:
         """Refresh token if needed via library."""
-        await self.hass.async_add_executor_job(self.yoto_client.check_and_refresh_token)
+        await self.yoto_client.check_and_refresh_token()
 
     async def async_pause_player(self, player_id: str) -> None:
         """Pause playback on the player."""
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(self.yoto_client.pause, player_id)
+        await self.yoto_client.pause(player_id)
 
     async def async_resume_player(self, player_id: str) -> None:
         """Resume playback on the player."""
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(self.yoto_client.resume, player_id)
+        await self.yoto_client.resume(player_id)
 
     async def async_stop_player(self, player_id: str) -> None:
         """Stop playback on the player."""
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(self.yoto_client.stop, player_id)
+        await self.yoto_client.stop(player_id)
 
     async def async_set_player_config(self, player_id: str, **fields: Any) -> None:
         """Update PlayerConfig fields on the device. Pass v3 field names."""
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
-            lambda: self.yoto_client.set_player_config(player_id, **fields)
-        )
+        await self.yoto_client.set_player_config(player_id, **fields)
         # The lib doesn't mirror PlayerConfig writes back onto the local
         # player.info.config, so refetch /config to surface the new value
         # before the next 5-minute poll tick.
-        await self.hass.async_add_executor_job(
-            self.yoto_client.update_player_info, player_id
-        )
+        await self.yoto_client.update_player_info(player_id)
         self.async_update_listeners()
 
     async def async_play_card(
@@ -168,68 +166,53 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
     ) -> None:
         """Play a card on the player."""
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
-            lambda: self.yoto_client.play_card(
-                player_id,
-                cardid,
-                seconds_in=secondsin,
-                cutoff=cutoff,
-                chapter_key=str(chapter) if chapter is not None else None,
-                track_key=str(trackkey) if trackkey is not None else None,
-            )
+        await self.yoto_client.play_card(
+            player_id,
+            cardid,
+            seconds_in=secondsin,
+            cutoff=cutoff,
+            chapter_key=str(chapter) if chapter is not None else None,
+            track_key=str(trackkey) if trackkey is not None else None,
         )
 
     async def async_seek(self, player_id: str, position: int) -> None:
         """Seek to a position in the current track."""
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
-            self.yoto_client.seek, player_id, position
-        )
+        await self.yoto_client.seek(player_id, position)
 
     async def async_next_track(self, player_id: str) -> None:
         """Skip to the next track."""
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(self.yoto_client.next_track, player_id)
+        await self.yoto_client.next_track(player_id)
 
     async def async_previous_track(self, player_id: str) -> None:
         """Skip to the previous track."""
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
-            self.yoto_client.previous_track, player_id
-        )
+        await self.yoto_client.previous_track(player_id)
 
     async def async_set_volume(self, player_id: str, volume: float) -> None:
         """Set player volume level."""
-        volume = int(round(volume * 100, 0))
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
-            self.yoto_client.set_volume, player_id, volume
-        )
+        await self.yoto_client.set_volume(player_id, int(round(volume * 100, 0)))
 
     async def async_set_sleep_timer(self, player_id: str, time: int) -> None:
         """Set sleep timer on the player."""
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
-            self.yoto_client.set_sleep_timer, player_id, int(time)
-        )
+        await self.yoto_client.set_sleep_timer(player_id, int(time))
 
     async def async_enable_disable_alarm(
         self, player_id: str, alarm: int, enable: bool
     ) -> None:
         """Enable or disable an alarm."""
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
-            self.yoto_client.set_alarm_enabled, player_id, alarm, enable
-        )
+        await self.yoto_client.set_alarm_enabled(player_id, alarm, enable)
 
     async def async_update_card_detail(self, cardId: str) -> None:
         """Get chapter and titles for the card"""
         _LOGGER.debug(f"{DOMAIN} - Updating Card details for:  {cardId}")
-        await self.hass.async_add_executor_job(
-            self.yoto_client.update_card_detail, cardId
-        )
+        await self.yoto_client.update_card_detail(cardId)
 
     async def async_update_library(self) -> None:
         """Update library details."""
         _LOGGER.debug(f"{DOMAIN} - Updating library details")
-        await self.hass.async_add_executor_job(self.yoto_client.update_library)
+        await self.yoto_client.update_library()

--- a/custom_components/yoto/coordinator.py
+++ b/custom_components/yoto/coordinator.py
@@ -63,7 +63,9 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator):
             except YotoError as err:
                 _LOGGER.debug(
                     "%s - request_status_push failed for %s: %s",
-                    DOMAIN, player_id, err,
+                    DOMAIN,
+                    player_id,
+                    err,
                 )
 
     async def _async_update_data(self) -> dict | None:

--- a/custom_components/yoto/entity.py
+++ b/custom_components/yoto/entity.py
@@ -23,9 +23,9 @@ class YotoEntity(CoordinatorEntity):
         return DeviceInfo(
             identifiers={(DOMAIN, self.player.id)},
             manufacturer="Yoto",
-            model=self.player.device_type,
+            model=self.player.info.device_type,
             name=self.player.name,
-            sw_version=self.player.firmware_version,
+            sw_version=self.player.info.firmware_version,
         )
 
     @callback

--- a/custom_components/yoto/entity.py
+++ b/custom_components/yoto/entity.py
@@ -1,6 +1,5 @@
 """Base entity for Yoto integration."""
 
-from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -27,10 +26,3 @@ class YotoEntity(CoordinatorEntity):
             name=self.player.name,
             sw_version=self.player.info.firmware_version,
         )
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        # Coordinator's api_callback fires from the paho-mqtt thread, so route
-        # the state write through the thread-safe scheduler instead of the
-        # default async_write_ha_state.
-        self.schedule_update_ha_state()

--- a/custom_components/yoto/light.py
+++ b/custom_components/yoto/light.py
@@ -150,12 +150,12 @@ class YotoLight(LightEntity, YotoEntity):
             r = g = b = 255
         if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs[ATTR_BRIGHTNESS]
-        elif (current_brightness := self.brightness):
+        elif current_brightness := self.brightness:
             brightness = current_brightness
         else:
             brightness = 255
         scale = brightness / 255
-        hex_color = "#%02x%02x%02x" % (
+        hex_color = "#{:02x}{:02x}{:02x}".format(
             round(r * scale),
             round(g * scale),
             round(b * scale),

--- a/custom_components/yoto/light.py
+++ b/custom_components/yoto/light.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Final
 
 from homeassistant.components.light import (
@@ -15,27 +17,59 @@ from homeassistant.components.light import (
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from yoto_api import YotoPlayer
+from yoto_api import YotoPlayer, caps_for
 
 from .const import DOMAIN
-from .coordinator import YotoConfigEntry
+from .coordinator import YotoConfigEntry, YotoDataUpdateCoordinator
 from .entity import YotoEntity
-from .utils import rgetattr
 
 _LOGGER = logging.getLogger(__name__)
 
-SENSOR_DESCRIPTIONS: Final[tuple[LightEntityDescription, ...]] = (
-    LightEntityDescription(
+
+@dataclass(frozen=True, kw_only=True)
+class YotoLightEntityDescription(LightEntityDescription):
+    """Yoto light entity."""
+
+    value: Callable[[YotoPlayer], str | None]
+    setter: Callable[[YotoDataUpdateCoordinator, YotoPlayer, str], Awaitable[None]]
+
+
+LIGHT_DESCRIPTIONS: Final[tuple[YotoLightEntityDescription, ...]] = (
+    YotoLightEntityDescription(
         key="config.day_ambient_colour",
         translation_key="day_ambient_colour",
+        value=lambda p: p.info.config.day_ambient_colour,
+        setter=lambda c, p, color: c.async_set_player_config(
+            p.id, day_ambient_colour=color
+        ),
         entity_category=EntityCategory.CONFIG,
     ),
-    LightEntityDescription(
+    YotoLightEntityDescription(
         key="config.night_ambient_colour",
         translation_key="night_ambient_colour",
+        value=lambda p: p.info.config.night_ambient_colour,
+        setter=lambda c, p, color: c.async_set_player_config(
+            p.id, night_ambient_colour=color
+        ),
         entity_category=EntityCategory.CONFIG,
     ),
 )
+
+
+def _parse_hex(value: str | None) -> tuple[int, int, int] | None:
+    if value is None:
+        return None
+    hex_val = value.lstrip("#")
+    if len(hex_val) != 6:
+        return None
+    try:
+        return (
+            int(hex_val[0:2], 16),
+            int(hex_val[2:4], 16),
+            int(hex_val[4:6], 16),
+        )
+    except ValueError:
+        return None
 
 
 async def async_setup_entry(
@@ -43,73 +77,91 @@ async def async_setup_entry(
     config_entry: YotoConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up sensor platform."""
+    """Set up light platform."""
     coordinator = config_entry.runtime_data
     entities: list[YotoLight] = []
-    for player_id in coordinator.yoto_manager.players.keys():
-        player: YotoPlayer = coordinator.yoto_manager.players[player_id]
-        for description in SENSOR_DESCRIPTIONS:
-            if rgetattr(player, description.key) is not None:
+    for player_id in coordinator.yoto_client.players.keys():
+        player: YotoPlayer = coordinator.yoto_client.players[player_id]
+        if not caps_for(player.device).has_ambient_light:
+            continue
+        for description in LIGHT_DESCRIPTIONS:
+            if description.value(player) is not None:
                 entities.append(YotoLight(coordinator, description, player))
     async_add_entities(entities)
 
 
 class YotoLight(LightEntity, YotoEntity):
-    """Yoto sensor class."""
+    """Yoto light entity.
+
+    Yoto stores ambient colour as a single hex RGB string where brightness
+    is folded into the channel values (`"#400000"` is a dim red). HA
+    prefers a separated model: `rgb_color` normalised so the max channel
+    is 255, plus an independent `brightness`. We translate between the
+    two on read and write.
+    """
+
+    entity_description: YotoLightEntityDescription
+    _attr_color_mode = ColorMode.RGB
+    _attr_supported_color_modes = {ColorMode.RGB}
 
     def __init__(
-        self, coordinator, description: LightEntityDescription, player: YotoPlayer
+        self,
+        coordinator,
+        description: YotoLightEntityDescription,
+        player: YotoPlayer,
     ) -> None:
-        """Initialize the sensor."""
         super().__init__(coordinator, player)
-        self._description = description
-        self._key = self._description.key
-        self._attr_unique_id = f"{DOMAIN}_{player.id}_{self._key}"
-        self._attr_translation_key = self._description.translation_key
-        self._attr_entity_category = description.entity_category
+        self.entity_description = description
+        self._attr_unique_id = f"{DOMAIN}_{player.id}_{description.key}"
 
     @property
-    def color_mode(self) -> ColorMode:
-        """Return the color mode."""
-        return ColorMode.RGB
-
-    @property
-    def supported_color_modes(self) -> list[ColorMode]:
-        """Return the color modes the sensor supports."""
-        return [ColorMode.RGB]
-
-    @property
-    def rgb_color(self) -> tuple[int, int, int]:
-        """Return the RGB color"""
-        hex_val = rgetattr(self.player, self._key).lstrip("#")
-        rgb_val = tuple(int(hex_val[i : i + 2], 16) for i in (0, 2, 4))
-        return rgb_val
+    def _rgb_raw(self) -> tuple[int, int, int] | None:
+        return _parse_hex(self.entity_description.value(self.player))
 
     @property
     def is_on(self) -> bool:
-        """Return if the light is on."""
-        status = rgetattr(self.player, self._key)
-        if status != "#0":
-            return True
-        else:
-            return False
+        rgb = self._rgb_raw
+        return rgb is not None and max(rgb) > 0
+
+    @property
+    def brightness(self) -> int | None:
+        rgb = self._rgb_raw
+        return max(rgb) if rgb is not None else None
+
+    @property
+    def rgb_color(self) -> tuple[int, int, int] | None:
+        rgb = self._rgb_raw
+        if rgb is None:
+            return None
+        peak = max(rgb)
+        if peak == 0:
+            return (0, 0, 0)
+        return tuple(round(c * 255 / peak) for c in rgb)
 
     async def async_turn_off(self, **kwargs) -> None:
-        """Turn device off."""
-        await self.coordinator.async_set_light(self.player.id, self._key, "#0")
-        self.async_write_ha_state()
+        await self._write("#0")
 
     async def async_turn_on(self, **kwargs) -> None:
-        """Turn device on."""
-        _LOGGER.debug(f"{DOMAIN} - Turn on light Args: {kwargs}")
         if ATTR_RGB_COLOR in kwargs:
-            rgb = kwargs[ATTR_RGB_COLOR]
-            hex_color = "#%02x%02x%02x" % rgb
-        elif ATTR_BRIGHTNESS in kwargs:
-            # Placeholder for now.  Not sure we can use this yet. Need to see how my v3 handles dimmed rgb values
-            # brightness = kwargs[ATTR_BRIGHTNESS]
-            hex_color = "#ffffff"
+            r, g, b = kwargs[ATTR_RGB_COLOR]
+        elif (current := self.rgb_color) is not None:
+            r, g, b = current
         else:
-            hex_color = "#ffffff"
-        await self.coordinator.async_set_light(self.player.id, self._key, hex_color)
+            r = g = b = 255
+        if ATTR_BRIGHTNESS in kwargs:
+            brightness = kwargs[ATTR_BRIGHTNESS]
+        elif (current_brightness := self.brightness):
+            brightness = current_brightness
+        else:
+            brightness = 255
+        scale = brightness / 255
+        hex_color = "#%02x%02x%02x" % (
+            round(r * scale),
+            round(g * scale),
+            round(b * scale),
+        )
+        await self._write(hex_color)
+
+    async def _write(self, hex_color: str) -> None:
+        await self.entity_description.setter(self.coordinator, self.player, hex_color)
         self.async_write_ha_state()

--- a/custom_components/yoto/manifest.json
+++ b/custom_components/yoto/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/cdnninja/yoto_ha/issues",
   "loggers": ["yoto", "yoto_api", "paho_mqtt"],
-  "requirements": ["yoto-api == 3.1.0"],
+  "requirements": ["yoto-api==3.1.0"],
   "version": "3.2.1"
 }

--- a/custom_components/yoto/manifest.json
+++ b/custom_components/yoto/manifest.json
@@ -8,8 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/cdnninja/yoto_ha/issues",
   "loggers": ["yoto", "yoto_api", "paho_mqtt"],
-  "requirements": [
-    "yoto-api == 3.1.0"
-  ],
+  "requirements": ["yoto-api == 3.1.0"],
   "version": "3.2.1"
 }

--- a/custom_components/yoto/manifest.json
+++ b/custom_components/yoto/manifest.json
@@ -8,8 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/cdnninja/yoto_ha/issues",
   "loggers": ["yoto", "yoto_api", "paho_mqtt"],
-  "requirements": [
-    "yoto-api @ git+https://github.com/piitaya/yoto_api.git@837ba5b19fa9ec4d4273fd06dfaab03dde0f2f0e"
-  ],
+  "requirements": ["yoto-api @ git+https://github.com/piitaya/yoto_api.git@837ba5b19fa9ec4d4273fd06dfaab03dde0f2f0e"],
   "version": "3.2.1"
 }

--- a/custom_components/yoto/manifest.json
+++ b/custom_components/yoto/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/cdnninja/yoto_ha/issues",
   "loggers": ["yoto", "yoto_api", "paho_mqtt"],
   "requirements": [
-    "yoto-api @ git+https://github.com/piitaya/yoto_api.git@837ba5b19fa9ec4d4273fd06dfaab03dde0f2f0e"
+    "yoto-api @ git+https://github.com/piitaya/yoto_api.git@ae9a538427292131446b797414cb76d7e472f4b6"
   ],
   "version": "3.2.1"
 }

--- a/custom_components/yoto/manifest.json
+++ b/custom_components/yoto/manifest.json
@@ -8,6 +8,8 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/cdnninja/yoto_ha/issues",
   "loggers": ["yoto", "yoto_api", "paho_mqtt"],
-  "requirements": ["yoto-api @ git+https://github.com/piitaya/yoto_api.git@837ba5b19fa9ec4d4273fd06dfaab03dde0f2f0e"],
+  "requirements": [
+    "yoto-api @ git+https://github.com/piitaya/yoto_api.git@837ba5b19fa9ec4d4273fd06dfaab03dde0f2f0e"
+  ],
   "version": "3.2.1"
 }

--- a/custom_components/yoto/manifest.json
+++ b/custom_components/yoto/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/cdnninja/yoto_ha/issues",
   "loggers": ["yoto", "yoto_api", "paho_mqtt"],
-  "requirements": ["yoto-api==2.3.0"],
+  "requirements": ["yoto-api @ git+https://github.com/piitaya/yoto_api.git@837ba5b19fa9ec4d4273fd06dfaab03dde0f2f0e"],
   "version": "3.2.1"
 }

--- a/custom_components/yoto/manifest.json
+++ b/custom_components/yoto/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/cdnninja/yoto_ha/issues",
   "loggers": ["yoto", "yoto_api", "paho_mqtt"],
   "requirements": [
-    "yoto-api @ git+https://github.com/piitaya/yoto_api.git@ae9a538427292131446b797414cb76d7e472f4b6"
+    "yoto-api == 3.1.0"
   ],
   "version": "3.2.1"
 }

--- a/custom_components/yoto/media_player.py
+++ b/custom_components/yoto/media_player.py
@@ -36,8 +36,8 @@ async def async_setup_entry(
     """Set up Media Player platform."""
     coordinator = config_entry.runtime_data
     entities: list[YotoMediaPlayer] = []
-    for player_id in coordinator.yoto_manager.players.keys():
-        player: YotoPlayer = coordinator.yoto_manager.players[player_id]
+    for player_id in coordinator.yoto_client.players.keys():
+        player: YotoPlayer = coordinator.yoto_client.players[player_id]
         entities.append(YotoMediaPlayer(coordinator, player))
     async_add_entities(entities)
 
@@ -58,7 +58,6 @@ class YotoMediaPlayer(MediaPlayerEntity, YotoEntity):
         """Initialize the media player."""
         super().__init__(coordinator, player)
         self._id = f"{player.name}"
-        # self.data = data
         self._key = "media_player"
         self._attr_unique_id = f"{DOMAIN}_{player.id}_media_player"
         self._attr_name = None
@@ -97,6 +96,10 @@ class YotoMediaPlayer(MediaPlayerEntity, YotoEntity):
     ) -> None:
         """Play media."""
         cardid, chapterid, trackid, time = split_media_id(media_id)
+        # Yoto needs a trackKey to jump to a specific chapter; without it the
+        # device ignores chapterKey and keeps playing the current track.
+        if chapterid is not None and trackid is None:
+            trackid = "01"
         _LOGGER.debug(
             f"{DOMAIN} - Media requested:  {media_id} Cardid:  {cardid}, chapterid:  {chapterid}, trackid: {trackid}"
         )
@@ -129,14 +132,13 @@ class YotoMediaPlayer(MediaPlayerEntity, YotoEntity):
         await self.coordinator.async_update_library()
         if media_content_id in (None, "library"):
             return await self.async_convert_library_to_browse_media()
-        else:
-            return await self.async_convert_chapter_to_browse_media(media_content_id)
+        return await self.async_convert_card_to_browse_media(media_content_id)
 
     async def async_convert_library_to_browse_media(self) -> BrowseMedia:
         """Browse library content."""
         children = []
 
-        for item in self.coordinator.yoto_manager.library.values():
+        for item in self.coordinator.yoto_client.library.values():
             children.append(
                 BrowseMedia(
                     media_content_id=item.id,
@@ -159,68 +161,47 @@ class YotoMediaPlayer(MediaPlayerEntity, YotoEntity):
             children_media_class=MediaClass.MUSIC,
         )
 
-    async def async_convert_chapter_to_browse_media(self, cardid: str) -> BrowseMedia:
-        """Browse chapter content for a card."""
-        children = []
-        _LOGGER.debug(
-            f"{DOMAIN} - Chapters:  {self.coordinator.yoto_manager.library[cardid].chapters}"
-        )
+    async def async_convert_card_to_browse_media(self, cardid: str) -> BrowseMedia:
+        """Browse a card: flat list of (chapter, track) playable leaves."""
         await self.coordinator.async_update_card_detail(cardid)
-        for item in self.coordinator.yoto_manager.library[cardid].chapters.values():
-            _LOGGER.debug(f"{DOMAIN} - Chapter processing:  {item}")
-            children.append(
-                BrowseMedia(
-                    media_content_id=cardid + "+" + item.key,
-                    media_class=MediaClass.MUSIC,
-                    media_content_type=MediaType.MUSIC,
-                    title=item.title,
-                    can_expand=False,
-                    can_play=True,
-                    thumbnail=item.icon,
-                )
-            )
-        _LOGGER.debug(f"{DOMAIN} - Browse media:  {children}")
-        return BrowseMedia(
-            media_content_id=cardid,
-            media_class=MediaClass.MUSIC,
-            media_content_type=MediaType.MUSIC,
-            title=self.coordinator.yoto_manager.library[cardid].title,
-            can_expand=False,
-            can_play=True,
-            children=children,
-            children_media_class=MediaClass.MUSIC,
-        )
-
-    async def async_convert_track_to_browse_media(
-        self, cardid: str, chapterid: str
-    ) -> BrowseMedia:
-        """Browse track content for a chapter."""
-        children = []
-        if self.coordinator.yoto_manager.library[cardid].chapters[chapterid].tracks:
-            for item in (
-                self.coordinator.yoto_manager.library[cardid]
-                .chapters[chapterid]
-                .tracks.values()
-            ):
+        card = self.coordinator.yoto_client.library[cardid]
+        children: list[BrowseMedia] = []
+        for chapter in card.chapters.values():
+            if not chapter.tracks:
                 children.append(
                     BrowseMedia(
-                        media_content_id=cardid + "+" + chapterid + "+" + item.key,
+                        media_content_id=f"{cardid}+{chapter.key}",
                         media_class=MediaClass.MUSIC,
                         media_content_type=MediaType.MUSIC,
-                        title=item.title,
+                        title=chapter.title,
                         can_expand=False,
                         can_play=True,
-                        thumbnail=item.icon,
+                        thumbnail=chapter.icon,
+                    )
+                )
+                continue
+            for track in chapter.tracks.values():
+                if chapter.title == track.title:
+                    title = chapter.title
+                else:
+                    title = f"{chapter.title} - {track.title}"
+                children.append(
+                    BrowseMedia(
+                        media_content_id=f"{cardid}+{chapter.key}+{track.key}",
+                        media_class=MediaClass.MUSIC,
+                        media_content_type=MediaType.MUSIC,
+                        title=title,
+                        can_expand=False,
+                        can_play=True,
+                        thumbnail=track.icon or chapter.icon,
                     )
                 )
         return BrowseMedia(
             media_content_id=cardid,
             media_class=MediaClass.MUSIC,
             media_content_type=MediaType.MUSIC,
-            title=self.coordinator.yoto_manager.library[cardid]
-            .chapters[chapterid]
-            .title,
-            can_expand=False,
+            title=card.title,
+            can_expand=True,
             can_play=True,
             children=children,
             children_media_class=MediaClass.MUSIC,
@@ -244,45 +225,41 @@ class YotoMediaPlayer(MediaPlayerEntity, YotoEntity):
     @property
     def state(self) -> MediaPlayerState:
         """Return the playback state."""
-
-        if self.player.playback_status == "paused":
+        playback_status = self.player.last_event.playback_status
+        if playback_status == "paused":
             return MediaPlayerState.PAUSED
-        if self.player.playback_status == "playing":
+        if playback_status == "playing":
             return MediaPlayerState.PLAYING
-        if self.player.playback_status == "stopped":
+        if playback_status == "stopped":
             return MediaPlayerState.IDLE
-        if not self.player.online:
+        if not self.player.status.is_online:
             return MediaPlayerState.OFF
-        if self.player.online:
-            return MediaPlayerState.ON
+        return MediaPlayerState.ON
 
     @property
     def volume_level(self) -> float | None:
         """Return the volume level."""
-        if self.player.volume:
-            return self.player.volume / 16
-        else:
-            return None
+        return self.player.last_event.volume_percentage
 
     @property
     def media_duration(self) -> int | None:
         """Return the duration of the current media in seconds."""
-        return self.player.track_length
+        return self.player.last_event.track_length
 
     @property
     def media_position_updated_at(self) -> datetime | None:
         """Return the last time the media position was updated."""
-        if self.player.track_position is None:
+        if self.player.last_event.position is None:
             return None
-        return self.player.last_updated_at
+        return self.player.last_event_received_at
 
     @property
     def media_artist(self) -> str | None:
         """Return the artist of the current media."""
-        if self.player.card_id in self.coordinator.yoto_manager.library:
-            return self.coordinator.yoto_manager.library[self.player.card_id].author
-        else:
-            return None
+        card_id = self.player.last_event.card_id
+        if card_id and card_id in self.coordinator.yoto_client.library:
+            return self.coordinator.yoto_client.library[card_id].author
+        return None
 
     @property
     def media_image_remotely_accessible(self) -> bool:
@@ -292,95 +269,58 @@ class YotoMediaPlayer(MediaPlayerEntity, YotoEntity):
     @property
     def media_album_name(self) -> str | None:
         """Return the album name of the current media."""
-        if self.player.card_id in self.coordinator.yoto_manager.library:
-            return self.coordinator.yoto_manager.library[self.player.card_id].title
-        else:
-            return None
+        card_id = self.player.last_event.card_id
+        if card_id and card_id in self.coordinator.yoto_client.library:
+            return self.coordinator.yoto_client.library[card_id].title
+        return None
 
     @property
     def media_image_url(self) -> str | None:
         """Return the image URL of the current media."""
-        if self.player.card_id in self.coordinator.yoto_manager.library:
-            return self.coordinator.yoto_manager.library[
-                self.player.card_id
-            ].cover_image_large
-        else:
-            return None
+        card_id = self.player.last_event.card_id
+        if card_id and card_id in self.coordinator.yoto_client.library:
+            return self.coordinator.yoto_client.library[card_id].cover_image_large
+        return None
 
     @property
     def media_position(self) -> int | None:
         """Return the current position of the playback."""
-        return self.player.track_position
+        return self.player.last_event.position
 
     @property
     def media_content_id(self) -> str | None:
         """Return the current media content ID."""
-        if self.player.card_id and self.player.chapter_key and self.player.track_key:
-            return (
-                self.player.card_id
-                + "+"
-                + self.player.chapter_key
-                + "+"
-                + self.player.track_key
-            )
-        else:
-            return None
+        event = self.player.last_event
+        if event.card_id and event.chapter_key and event.track_key:
+            return event.card_id + "+" + event.chapter_key + "+" + event.track_key
+        return None
 
     @property
     def media_title(self) -> str | None:
         """Return the current media title."""
-        if self.player.chapter_title == self.player.track_title:
-            return self.player.chapter_title
-        elif self.player.chapter_title and self.player.track_title:
-            return self.player.chapter_title + " - " + self.player.track_title
-        else:
-            return self.player.chapter_title
+        event = self.player.last_event
+        if event.chapter_title == event.track_title:
+            return event.chapter_title
+        if event.chapter_title and event.track_title:
+            return event.chapter_title + " - " + event.track_title
+        return event.chapter_title
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return device specific state attributes."""
         state_attributes: dict[str, Any] = {}
-        if self.player.card_id and self.player.chapter_key:
-            if (
-                self.player.card_id in self.coordinator.yoto_manager.library
-                and self.coordinator.yoto_manager.library[self.player.card_id].chapters
-            ):
-                if (
-                    self.player.chapter_key
-                    in self.coordinator.yoto_manager.library[
-                        self.player.card_id
-                    ].chapters
-                ):
-                    if (
-                        self.player.track_key
-                        in self.coordinator.yoto_manager.library[self.player.card_id]
-                        .chapters[self.player.chapter_key]
-                        .tracks
-                    ):
-                        if (
-                            self.coordinator.yoto_manager.library[self.player.card_id]
-                            .chapters[self.player.chapter_key]
-                            .icon
-                        ):
-                            state_attributes["media_chapter_icon"] = (
-                                self.coordinator.yoto_manager.library[
-                                    self.player.card_id
-                                ]
-                                .chapters[self.player.chapter_key]
-                                .icon
-                            )
-                        if (
-                            self.coordinator.yoto_manager.library[self.player.card_id]
-                            .chapters[self.player.chapter_key]
-                            .tracks[self.player.track_key]
-                            .icon
-                        ):
-                            state_attributes["media_track_icon"] = (
-                                self.coordinator.yoto_manager.library[
-                                    self.player.card_id
-                                ]
-                                .chapters[self.player.chapter_key]
-                                .tracks[self.player.track_key]
-                                .icon
-                            )
+        event = self.player.last_event
+        if not event.card_id or not event.chapter_key:
+            return state_attributes
+        card = self.coordinator.yoto_client.library.get(event.card_id)
+        if card is None or not card.chapters:
+            return state_attributes
+        chapter = card.chapters.get(event.chapter_key)
+        if chapter is None:
+            return state_attributes
+        if chapter.icon:
+            state_attributes["media_chapter_icon"] = chapter.icon
+        track = (chapter.tracks or {}).get(event.track_key)
+        if track is not None and track.icon:
+            state_attributes["media_track_icon"] = track.icon
         return state_attributes

--- a/custom_components/yoto/media_player.py
+++ b/custom_components/yoto/media_player.py
@@ -207,6 +207,8 @@ class YotoMediaPlayer(MediaPlayerEntity, YotoEntity):
     @property
     def state(self) -> MediaPlayerState:
         """Return the playback state."""
+        if not self.player.status.is_online:
+            return MediaPlayerState.OFF
         playback_status = self.player.last_event.playback_status
         if playback_status == "paused":
             return MediaPlayerState.PAUSED
@@ -214,8 +216,6 @@ class YotoMediaPlayer(MediaPlayerEntity, YotoEntity):
             return MediaPlayerState.PLAYING
         if playback_status == "stopped":
             return MediaPlayerState.IDLE
-        if not self.player.status.is_online:
-            return MediaPlayerState.OFF
         return MediaPlayerState.ON
 
     @property

--- a/custom_components/yoto/media_player.py
+++ b/custom_components/yoto/media_player.py
@@ -96,10 +96,6 @@ class YotoMediaPlayer(MediaPlayerEntity, YotoEntity):
     ) -> None:
         """Play media."""
         cardid, chapterid, trackid, time = split_media_id(media_id)
-        # Yoto needs a trackKey to jump to a specific chapter; without it the
-        # device ignores chapterKey and keeps playing the current track.
-        if chapterid is not None and trackid is None:
-            trackid = "01"
         _LOGGER.debug(
             f"{DOMAIN} - Media requested:  {media_id} Cardid:  {cardid}, chapterid:  {chapterid}, trackid: {trackid}"
         )
@@ -132,7 +128,7 @@ class YotoMediaPlayer(MediaPlayerEntity, YotoEntity):
         await self.coordinator.async_update_library()
         if media_content_id in (None, "library"):
             return await self.async_convert_library_to_browse_media()
-        return await self.async_convert_card_to_browse_media(media_content_id)
+        return await self.async_convert_chapter_to_browse_media(media_content_id)
 
     async def async_convert_library_to_browse_media(self) -> BrowseMedia:
         """Browse library content."""
@@ -161,47 +157,33 @@ class YotoMediaPlayer(MediaPlayerEntity, YotoEntity):
             children_media_class=MediaClass.MUSIC,
         )
 
-    async def async_convert_card_to_browse_media(self, cardid: str) -> BrowseMedia:
-        """Browse a card: flat list of (chapter, track) playable leaves."""
+    async def async_convert_chapter_to_browse_media(self, cardid: str) -> BrowseMedia:
+        """Browse chapter content for a card."""
+        children = []
+        _LOGGER.debug(
+            f"{DOMAIN} - Chapters:  {self.coordinator.yoto_client.library[cardid].chapters}"
+        )
         await self.coordinator.async_update_card_detail(cardid)
-        card = self.coordinator.yoto_client.library[cardid]
-        children: list[BrowseMedia] = []
-        for chapter in card.chapters.values():
-            if not chapter.tracks:
-                children.append(
-                    BrowseMedia(
-                        media_content_id=f"{cardid}+{chapter.key}",
-                        media_class=MediaClass.MUSIC,
-                        media_content_type=MediaType.MUSIC,
-                        title=chapter.title,
-                        can_expand=False,
-                        can_play=True,
-                        thumbnail=chapter.icon,
-                    )
+        for item in self.coordinator.yoto_client.library[cardid].chapters.values():
+            _LOGGER.debug(f"{DOMAIN} - Chapter processing:  {item}")
+            children.append(
+                BrowseMedia(
+                    media_content_id=cardid + "+" + item.key,
+                    media_class=MediaClass.MUSIC,
+                    media_content_type=MediaType.MUSIC,
+                    title=item.title,
+                    can_expand=False,
+                    can_play=True,
+                    thumbnail=item.icon,
                 )
-                continue
-            for track in chapter.tracks.values():
-                if chapter.title == track.title:
-                    title = chapter.title
-                else:
-                    title = f"{chapter.title} - {track.title}"
-                children.append(
-                    BrowseMedia(
-                        media_content_id=f"{cardid}+{chapter.key}+{track.key}",
-                        media_class=MediaClass.MUSIC,
-                        media_content_type=MediaType.MUSIC,
-                        title=title,
-                        can_expand=False,
-                        can_play=True,
-                        thumbnail=track.icon or chapter.icon,
-                    )
-                )
+            )
+        _LOGGER.debug(f"{DOMAIN} - Browse media:  {children}")
         return BrowseMedia(
             media_content_id=cardid,
             media_class=MediaClass.MUSIC,
             media_content_type=MediaType.MUSIC,
-            title=card.title,
-            can_expand=True,
+            title=self.coordinator.yoto_client.library[cardid].title,
+            can_expand=False,
             can_play=True,
             children=children,
             children_media_class=MediaClass.MUSIC,

--- a/custom_components/yoto/media_source.py
+++ b/custom_components/yoto/media_source.py
@@ -32,22 +32,22 @@ class YotoMediaSource(MediaSource):
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         """Provides the URL to play the media."""
         cardid, chapterid, trackid, time = split_media_id(item.identifier)
-        if len(self.coordinator.yoto_manager.library[cardid].chapters.keys()) == 0:
+        if len(self.coordinator.yoto_client.library[cardid].chapters.keys()) == 0:
             await self.coordinator.async_update_card_detail(cardid)
         if chapterid is None:
             chapterid = next(
-                iter(self.coordinator.yoto_manager.library[cardid].chapters)
+                iter(self.coordinator.yoto_client.library[cardid].chapters)
             )
         if trackid is None:
             trackid = next(
                 iter(
-                    self.coordinator.yoto_manager.library[cardid]
+                    self.coordinator.yoto_client.library[cardid]
                     .chapters[chapterid]
                     .tracks
                 )
             )
         track = (
-            self.coordinator.yoto_manager.library[cardid]
+            self.coordinator.yoto_client.library[cardid]
             .chapters[chapterid]
             .tracks[trackid]
         )
@@ -83,7 +83,7 @@ class YotoMediaSource(MediaSource):
     async def async_convert_library_to_browse_media(self) -> BrowseMediaSource:
         """Build media source for the library."""
         children = []
-        for item in self.coordinator.yoto_manager.library.values():
+        for item in self.coordinator.yoto_client.library.values():
             children.append(
                 BrowseMediaSource(
                     domain=DOMAIN,
@@ -113,9 +113,9 @@ class YotoMediaSource(MediaSource):
     ) -> BrowseMediaSource:
         children = []
 
-        if len(self.coordinator.yoto_manager.library[cardid].chapters.keys()) == 0:
+        if len(self.coordinator.yoto_client.library[cardid].chapters.keys()) == 0:
             await self.coordinator.async_update_card_detail(cardid)
-        for item in self.coordinator.yoto_manager.library[cardid].chapters.values():
+        for item in self.coordinator.yoto_client.library[cardid].chapters.values():
             _LOGGER.debug(f"{DOMAIN} - Chapter processing:  {item}")
             children.append(
                 BrowseMediaSource(
@@ -134,7 +134,7 @@ class YotoMediaSource(MediaSource):
             identifier=cardid,
             media_class=MediaClass.MUSIC,
             media_content_type=MediaType.MUSIC,
-            title=self.coordinator.yoto_manager.library[cardid].title,
+            title=self.coordinator.yoto_client.library[cardid].title,
             can_expand=False,
             can_play=True,
             children=children,
@@ -146,9 +146,9 @@ class YotoMediaSource(MediaSource):
     ) -> BrowseMediaSource:
         """Build media source for tracks of a chapter."""
         children = []
-        if self.coordinator.yoto_manager.library[cardid].chapters[chapterid].tracks:
+        if self.coordinator.yoto_client.library[cardid].chapters[chapterid].tracks:
             for item in (
-                self.coordinator.yoto_manager.library[cardid]
+                self.coordinator.yoto_client.library[cardid]
                 .chapters[chapterid]
                 .tracks.values()
             ):
@@ -169,7 +169,7 @@ class YotoMediaSource(MediaSource):
             identifier=cardid,
             media_class=MediaClass.MUSIC,
             media_content_type=MediaType.MUSIC,
-            title=self.coordinator.yoto_manager.library[cardid]
+            title=self.coordinator.yoto_client.library[cardid]
             .chapters[chapterid]
             .title,
             can_expand=False,

--- a/custom_components/yoto/number.py
+++ b/custom_components/yoto/number.py
@@ -29,9 +29,7 @@ class YotoNumberEntityDescription(NumberEntityDescription):
     """Yoto number entity."""
 
     value: Callable[[YotoPlayer], int | None]
-    setter: Callable[
-        [YotoDataUpdateCoordinator, YotoPlayer, int], Awaitable[None]
-    ]
+    setter: Callable[[YotoDataUpdateCoordinator, YotoPlayer, int], Awaitable[None]]
     available: Callable[[YotoPlayer], bool] | None = None
     always_load: bool = False
 
@@ -53,9 +51,7 @@ NUMBER_DESCRIPTIONS: Final[tuple[YotoNumberEntityDescription, ...]] = (
         key="config.day_max_volume_limit",
         translation_key="day_max_volume_limit",
         value=lambda p: p.info.config.day_max_volume_limit,
-        setter=lambda c, p, v: c.async_set_player_config(
-            p.id, day_max_volume_limit=v
-        ),
+        setter=lambda c, p, v: c.async_set_player_config(p.id, day_max_volume_limit=v),
         native_min_value=0,
         native_max_value=16,
         native_step=1,
@@ -137,9 +133,7 @@ class YotoNumber(NumberEntity, YotoEntity):
         return super().available and (check is None or check(self.player))
 
     async def async_set_native_value(self, value: float) -> None:
-        await self.entity_description.setter(
-            self.coordinator, self.player, int(value)
-        )
+        await self.entity_description.setter(self.coordinator, self.player, int(value))
         self.async_write_ha_state()
 
 
@@ -156,9 +150,7 @@ class YotoSleepTimerNumber(NumberEntity, YotoEntity):
 
     def __init__(self, coordinator, player: YotoPlayer) -> None:
         super().__init__(coordinator, player)
-        self._attr_unique_id = (
-            f"{DOMAIN}_{player.id}_sleep_timer_seconds_remaining"
-        )
+        self._attr_unique_id = f"{DOMAIN}_{player.id}_sleep_timer_seconds_remaining"
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/yoto/number.py
+++ b/custom_components/yoto/number.py
@@ -1,8 +1,10 @@
-"""Sensor for Yoto integration."""
+"""Number entities for Yoto integration."""
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Final
 
 from homeassistant.components.number import (
@@ -16,55 +18,77 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from yoto_api import YotoPlayer
 
 from .const import DOMAIN
-from .coordinator import YotoConfigEntry
+from .coordinator import YotoConfigEntry, YotoDataUpdateCoordinator
 from .entity import YotoEntity
-from .utils import rgetattr
 
 _LOGGER = logging.getLogger(__name__)
 
-SENSOR_DESCRIPTIONS: Final[tuple[NumberEntityDescription, ...]] = (
-    NumberEntityDescription(
+
+@dataclass(frozen=True, kw_only=True)
+class YotoNumberEntityDescription(NumberEntityDescription):
+    """Yoto number entity."""
+
+    value: Callable[[YotoPlayer], int | None]
+    setter: Callable[
+        [YotoDataUpdateCoordinator, YotoPlayer, int], Awaitable[None]
+    ]
+    available: Callable[[YotoPlayer], bool] | None = None
+    always_load: bool = False
+
+
+NUMBER_DESCRIPTIONS: Final[tuple[YotoNumberEntityDescription, ...]] = (
+    YotoNumberEntityDescription(
         key="config.night_max_volume_limit",
         translation_key="night_max_volume_limit",
+        value=lambda p: p.info.config.night_max_volume_limit,
+        setter=lambda c, p, v: c.async_set_player_config(
+            p.id, night_max_volume_limit=v
+        ),
         native_min_value=0,
         native_max_value=16,
         native_step=1,
         entity_category=EntityCategory.CONFIG,
     ),
-    NumberEntityDescription(
+    YotoNumberEntityDescription(
         key="config.day_max_volume_limit",
         translation_key="day_max_volume_limit",
+        value=lambda p: p.info.config.day_max_volume_limit,
+        setter=lambda c, p, v: c.async_set_player_config(
+            p.id, day_max_volume_limit=v
+        ),
         native_min_value=0,
         native_max_value=16,
         native_step=1,
         entity_category=EntityCategory.CONFIG,
     ),
-    NumberEntityDescription(
+    YotoNumberEntityDescription(
         key="config.day_display_brightness",
         translation_key="day_display_brightness",
+        value=lambda p: p.info.config.day_display_brightness,
+        setter=lambda c, p, v: c.async_set_player_config(
+            p.id, day_display_brightness=v
+        ),
+        available=lambda p: not p.info.config.day_display_brightness_auto,
+        always_load=True,
         native_min_value=0,
         native_max_value=100,
         native_step=1,
         native_unit_of_measurement=PERCENTAGE,
         entity_category=EntityCategory.CONFIG,
     ),
-    NumberEntityDescription(
+    YotoNumberEntityDescription(
         key="config.night_display_brightness",
         translation_key="night_display_brightness",
+        value=lambda p: p.info.config.night_display_brightness,
+        setter=lambda c, p, v: c.async_set_player_config(
+            p.id, night_display_brightness=v
+        ),
+        available=lambda p: not p.info.config.night_display_brightness_auto,
+        always_load=True,
         native_min_value=0,
         native_max_value=100,
         native_step=1,
         native_unit_of_measurement=PERCENTAGE,
-        entity_category=EntityCategory.CONFIG,
-    ),
-    NumberEntityDescription(
-        key="sleep_timer_seconds_remaining",
-        translation_key="sleep_timer",
-        device_class=NumberDeviceClass.DURATION,
-        native_min_value=0,
-        native_max_value=46500,
-        native_step=1,
-        native_unit_of_measurement=UnitOfTime.SECONDS,
         entity_category=EntityCategory.CONFIG,
     ),
 )
@@ -75,79 +99,72 @@ async def async_setup_entry(
     config_entry: YotoConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up sensor platform."""
+    """Set up number platform."""
     coordinator = config_entry.runtime_data
-    entities: list[YotoNumber] = []
-    for player_id in coordinator.yoto_manager.players.keys():
-        player: YotoPlayer = coordinator.yoto_manager.players[player_id]
-        for description in SENSOR_DESCRIPTIONS:
-            if rgetattr(player, description.key) is not None:
+    entities: list[NumberEntity] = []
+    for player_id in coordinator.yoto_client.players.keys():
+        player: YotoPlayer = coordinator.yoto_client.players[player_id]
+        for description in NUMBER_DESCRIPTIONS:
+            if description.always_load or description.value(player) is not None:
                 entities.append(YotoNumber(coordinator, description, player))
+        entities.append(YotoSleepTimerNumber(coordinator, player))
     async_add_entities(entities)
 
 
 class YotoNumber(NumberEntity, YotoEntity):
-    """Yoto sensor class."""
+    """Yoto number entity backed by a PlayerConfig field."""
+
+    entity_description: YotoNumberEntityDescription
 
     def __init__(
-        self, coordinator, description: NumberEntityDescription, player: YotoPlayer
+        self,
+        coordinator,
+        description: YotoNumberEntityDescription,
+        player: YotoPlayer,
     ) -> None:
-        """Initialize the sensor."""
         super().__init__(coordinator, player)
-        self._description = description
-        self._key = self._description.key
-        self._attr_unique_id = f"{DOMAIN}_{player.id}_{self._key}"
-        self._attr_device_class = self._description.device_class
-        self._attr_translation_key = self._description.translation_key
-        self._attr_entity_category = description.entity_category
+        self.entity_description = description
+        self._attr_unique_id = f"{DOMAIN}_{player.id}_{description.key}"
 
     @property
     def native_value(self) -> float | None:
-        """Return the entity value to represent the entity state."""
-        if (
-            self._key == "config.day_display_brightness"
-            or self._key == "config.night_display_brightness"
-        ) and rgetattr(self.player, self._key) == "auto":
-            return 100
-        else:
-            return rgetattr(self.player, self._key)
+        raw = self.entity_description.value(self.player)
+        return float(raw) if raw is not None else None
 
     @property
-    def native_min_value(self) -> float:
-        """Return native_min_value as reported in by the sensor"""
-        return self._description.native_min_value
-
-    @property
-    def native_max_value(self) -> float:
-        """Return native_max_value as reported in by the sensor"""
-        return self._description.native_max_value
-
-    @property
-    def native_step(self) -> float:
-        """Return step value as reported in by the sensor"""
-        return self._description.native_step
-
-    @property
-    def native_unit_of_measurement(self) -> str | None:
-        """Return the unit the value was reported in by the sensor"""
-        return self._description.native_unit_of_measurement
+    def available(self) -> bool:
+        check = self.entity_description.available
+        return super().available and (check is None or check(self.player))
 
     async def async_set_native_value(self, value: float) -> None:
-        """Update the current value."""
-        if (
-            self._key == "config.day_max_volume_limit"
-            or self._key == "config.night_max_volume_limit"
-        ):
-            await self.coordinator.async_set_max_volume(
-                self.player.id, self._key, value
-            )
-        elif (
-            self._key == "config.day_display_brightness"
-            or self._key == "config.night_display_brightness"
-        ):
-            await self.coordinator.async_set_brightness(
-                self.player.id, self._key, value
-            )
-        elif self._key == "sleep_timer_seconds_remaining":
-            await self.coordinator.async_set_sleep_timer(self.player.id, value)
+        await self.entity_description.setter(
+            self.coordinator, self.player, int(value)
+        )
+        self.async_write_ha_state()
+
+
+class YotoSleepTimerNumber(NumberEntity, YotoEntity):
+    """Number entity exposing the remaining seconds on the sleep timer."""
+
+    _attr_translation_key = "sleep_timer"
+    _attr_device_class = NumberDeviceClass.DURATION
+    _attr_native_min_value = 0
+    _attr_native_max_value = 46500
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator, player: YotoPlayer) -> None:
+        super().__init__(coordinator, player)
+        self._attr_unique_id = (
+            f"{DOMAIN}_{player.id}_sleep_timer_seconds_remaining"
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        remaining = self.player.last_event.sleep_timer_seconds
+        return float(remaining) if remaining is not None else None
+
+    async def async_set_native_value(self, value: float) -> None:
+        await self.coordinator.async_set_sleep_timer(self.player.id, int(value))
         self.async_write_ha_state()

--- a/custom_components/yoto/sensor.py
+++ b/custom_components/yoto/sensor.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Final
+from typing import Any, Final
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -33,6 +34,7 @@ _LOGGER = logging.getLogger(__name__)
 class YotoSensorEntityDescription(SensorEntityDescription):
     """Describe Yoto sensor entity."""
 
+    value: Callable[[YotoPlayer], Any]
     always_load: bool = False
 
 
@@ -43,6 +45,19 @@ SENSOR_DESCRIPTIONS: Final[tuple[YotoSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        always_load=True,
+        value=lambda player: max(
+            (
+                ts
+                for ts in (
+                    player.info_refreshed_at,
+                    player.status_refreshed_at,
+                    player.last_event_received_at,
+                )
+                if ts is not None
+            ),
+            default=None,
+        ),
     ),
     YotoSensorEntityDescription(
         key="battery_level_percentage",
@@ -50,31 +65,38 @@ SENSOR_DESCRIPTIONS: Final[tuple[YotoSensorEntityDescription, ...]] = (
         native_unit_of_measurement=PERCENTAGE,
         entity_category=EntityCategory.DIAGNOSTIC,
         always_load=True,
+        value=lambda player: player.status.battery_level_percentage,
     ),
     YotoSensorEntityDescription(
         key="temperature_celcius",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
+        suggested_display_precision=0,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value=lambda player: player.status.temperature_celcius,
     ),
     YotoSensorEntityDescription(
         key="ambient_light_sensor_reading",
         native_unit_of_measurement=LIGHT_LUX,
         device_class=SensorDeviceClass.ILLUMINANCE,
+        value=lambda player: player.status.ambient_light_sensor_reading,
     ),
     YotoSensorEntityDescription(
         key="wifi_strength",
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value=lambda player: player.status.wifi_strength,
     ),
     YotoSensorEntityDescription(
         key="battery_temperature",
         translation_key="battery_temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=0,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        value=lambda player: player.status.battery_temperature,
     ),
 )
 
@@ -87,13 +109,10 @@ async def async_setup_entry(
     """Set up sensor platform."""
     coordinator = config_entry.runtime_data
     entities: list[YotoSensor] = []
-    for player_id in coordinator.yoto_manager.players.keys():
-        player: YotoPlayer = coordinator.yoto_manager.players[player_id]
+    for player_id in coordinator.yoto_client.players.keys():
+        player: YotoPlayer = coordinator.yoto_client.players[player_id]
         for description in SENSOR_DESCRIPTIONS:
-            if (
-                getattr(player, description.key, None) is not None
-                or description.always_load
-            ):
+            if description.always_load or description.value(player) is not None:
                 entities.append(YotoSensor(coordinator, description, player))
     async_add_entities(entities)
 
@@ -101,29 +120,20 @@ async def async_setup_entry(
 class YotoSensor(SensorEntity, YotoEntity):
     """Yoto sensor class."""
 
+    entity_description: YotoSensorEntityDescription
+
     def __init__(
-        self, coordinator, description: SensorEntityDescription, player: YotoPlayer
+        self,
+        coordinator,
+        description: YotoSensorEntityDescription,
+        player: YotoPlayer,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, player)
-        self._description = description
-        self._key = self._description.key
-        self._attr_unique_id = f"{DOMAIN}_{player.id}_{self._key}"
-        self._attr_state_class = self._description.state_class
-        self._attr_device_class = self._description.device_class
-        self._attr_entity_category = self._description.entity_category
-        self._attr_entity_registry_enabled_default = (
-            description.entity_registry_enabled_default
-        )
-        self._attr_translation_key = self._description.translation_key
+        self.entity_description = description
+        self._attr_unique_id = f"{DOMAIN}_{player.id}_{description.key}"
 
     @property
     def native_value(self):
         """Return the value reported by the sensor."""
-        return getattr(self.player, self._key)
-
-    @property
-    def native_unit_of_measurement(self) -> str | None:
-        """Return the unit the value was reported in by the sensor"""
-
-        return self._description.native_unit_of_measurement
+        return self.entity_description.value(self.player)

--- a/custom_components/yoto/switch.py
+++ b/custom_components/yoto/switch.py
@@ -25,9 +25,7 @@ class YotoSwitchEntityDescription(SwitchEntityDescription):
     """Yoto switch entity."""
 
     value: Callable[[YotoPlayer], bool | None]
-    setter: Callable[
-        [YotoDataUpdateCoordinator, YotoPlayer, bool], Awaitable[None]
-    ]
+    setter: Callable[[YotoDataUpdateCoordinator, YotoPlayer, bool], Awaitable[None]]
 
 
 # Default brightness applied when the user turns off auto mode — Yoto's
@@ -146,9 +144,7 @@ class YotoEndOfTrackSleepSwitch(SwitchEntity, YotoEntity):
         event = self.player.last_event
         if event.track_length is not None and event.position is not None:
             seconds_to_end = event.track_length - event.position
-            await self.coordinator.async_set_sleep_timer(
-                self.player.id, seconds_to_end
-            )
+            await self.coordinator.async_set_sleep_timer(self.player.id, seconds_to_end)
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:

--- a/custom_components/yoto/switch.py
+++ b/custom_components/yoto/switch.py
@@ -1,8 +1,10 @@
-"""Sensor for Yoto integration."""
+"""Switch entities for Yoto integration."""
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Final
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
@@ -12,26 +14,60 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from yoto_api import YotoPlayer
 
 from .const import DOMAIN
-from .coordinator import YotoConfigEntry
+from .coordinator import YotoConfigEntry, YotoDataUpdateCoordinator
 from .entity import YotoEntity
-from .utils import parse_key
 
 _LOGGER = logging.getLogger(__name__)
 
-SENSOR_DESCRIPTIONS: Final[tuple[SwitchEntityDescription, ...]] = (
-    SwitchEntityDescription(
+
+@dataclass(frozen=True, kw_only=True)
+class YotoSwitchEntityDescription(SwitchEntityDescription):
+    """Yoto switch entity."""
+
+    value: Callable[[YotoPlayer], bool | None]
+    setter: Callable[
+        [YotoDataUpdateCoordinator, YotoPlayer, bool], Awaitable[None]
+    ]
+
+
+# Default brightness applied when the user turns off auto mode — Yoto's
+# API doesn't keep a "previous manual value", so we have to pick one.
+_DEFAULT_MANUAL_BRIGHTNESS = 100
+
+
+async def _set_brightness_auto(
+    coordinator: YotoDataUpdateCoordinator,
+    player: YotoPlayer,
+    field_auto: str,
+    field_value: str,
+    enabled: bool,
+) -> None:
+    if enabled:
+        await coordinator.async_set_player_config(player.id, **{field_auto: True})
+    else:
+        current = getattr(player.info.config, field_value)
+        await coordinator.async_set_player_config(
+            player.id, **{field_value: current or _DEFAULT_MANUAL_BRIGHTNESS}
+        )
+
+
+SWITCH_DESCRIPTIONS: Final[tuple[YotoSwitchEntityDescription, ...]] = (
+    YotoSwitchEntityDescription(
         key="night_display_brightness",
         translation_key="night_display_brightness",
+        value=lambda p: p.info.config.night_display_brightness_auto,
+        setter=lambda c, p, on: _set_brightness_auto(
+            c, p, "night_display_brightness_auto", "night_display_brightness", on
+        ),
         entity_category=EntityCategory.CONFIG,
     ),
-    SwitchEntityDescription(
+    YotoSwitchEntityDescription(
         key="day_display_brightness",
         translation_key="day_display_brightness",
-        entity_category=EntityCategory.CONFIG,
-    ),
-    SwitchEntityDescription(
-        key="end_of_track_sleep",
-        translation_key="end_of_track_sleep",
+        value=lambda p: p.info.config.day_display_brightness_auto,
+        setter=lambda c, p, on: _set_brightness_auto(
+            c, p, "day_display_brightness_auto", "day_display_brightness", on
+        ),
         entity_category=EntityCategory.CONFIG,
     ),
 )
@@ -42,101 +78,111 @@ async def async_setup_entry(
     config_entry: YotoConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up sensor platform."""
+    """Set up switch platform."""
     coordinator = config_entry.runtime_data
-    entities: list[YotoSwitch] = []
-    for player_id in coordinator.yoto_manager.players.keys():
-        player: YotoPlayer = coordinator.yoto_manager.players[player_id]
-        for index in range(len(player.config.alarms)):
-            alarm_description = SwitchEntityDescription(
-                key="alarms[" + str(index) + "]",
-                translation_key="alarm",
-                translation_placeholders={"number": str(index + 1)},
-                entity_category=EntityCategory.CONFIG,
-            )
-            entities.append(YotoSwitch(coordinator, alarm_description, player))
-
-        for description in SENSOR_DESCRIPTIONS:
+    entities: list[SwitchEntity] = []
+    for player_id in coordinator.yoto_client.players.keys():
+        player: YotoPlayer = coordinator.yoto_client.players[player_id]
+        for description in SWITCH_DESCRIPTIONS:
             entities.append(YotoSwitch(coordinator, description, player))
+        entities.append(YotoEndOfTrackSleepSwitch(coordinator, player))
+        for index in range(len(player.info.config.alarms)):
+            entities.append(YotoAlarmSwitch(coordinator, player, index))
     async_add_entities(entities)
 
 
 class YotoSwitch(SwitchEntity, YotoEntity):
-    """Yoto sensor class."""
+    """Yoto switch backed by a PlayerConfig boolean field."""
+
+    entity_description: YotoSwitchEntityDescription
 
     def __init__(
-        self, coordinator, description: SwitchEntityDescription, player: YotoPlayer
+        self,
+        coordinator,
+        description: YotoSwitchEntityDescription,
+        player: YotoPlayer,
     ) -> None:
-        """Initialize the sensor."""
         super().__init__(coordinator, player)
-        self._description = description
-        self._key = self._description.key
-        self._attr_unique_id = f"{DOMAIN}_{player.id}_switch_{self._key}"
-        if self._key.startswith("alarms"):
-            self._attribute, self._index = parse_key(self._key)
-        self._attr_translation_key = self._description.translation_key
-        if description.translation_placeholders:
-            self._attr_translation_placeholders = description.translation_placeholders
-        self._attr_entity_category = description.entity_category
+        self.entity_description = description
+        self._attr_unique_id = f"{DOMAIN}_{player.id}_switch_{description.key}"
 
     @property
     def is_on(self) -> bool | None:
-        """Return the entity value to represent the entity state."""
-        if (
-            self._key == "night_display_brightness"
-            or self._key == "day_display_brightness"
-        ):
-            if getattr(self.player.config, self._key) == "auto":
-                return True
-            else:
-                return False
-        elif self._key == "end_of_track_sleep":
-            if (
-                self.player.track_length is not None
-                and self.player.track_position is not None
-            ):
-                seconds_to_end = self.player.track_length - self.player.track_position
-                if abs(self.player.sleep_timer_seconds_remaining - seconds_to_end) <= 5:
-                    return True
-            return False
-        elif self._key.startswith("alarms"):
-            return getattr(self.player.config, self._attribute)[self._index].enabled
+        return self.entity_description.value(self.player)
+
+    async def async_turn_on(self, **kwargs) -> None:
+        await self.entity_description.setter(self.coordinator, self.player, True)
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:
-        """Turn the entity off."""
+        await self.entity_description.setter(self.coordinator, self.player, False)
+        self.async_write_ha_state()
+
+
+class YotoEndOfTrackSleepSwitch(SwitchEntity, YotoEntity):
+    """Synthetic switch: ON when the sleep timer is set to expire at the
+    end of the current track (give or take a few seconds)."""
+
+    _attr_translation_key = "end_of_track_sleep"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator, player: YotoPlayer) -> None:
+        super().__init__(coordinator, player)
+        self._attr_unique_id = f"{DOMAIN}_{player.id}_switch_end_of_track_sleep"
+
+    @property
+    def is_on(self) -> bool:
+        event = self.player.last_event
         if (
-            self._key == "night_display_brightness"
-            or self._key == "day_display_brightness"
+            event.track_length is None
+            or event.position is None
+            or event.sleep_timer_seconds is None
         ):
-            await self.coordinator.async_set_brightness(self.player.id, self._key, "0")
-        elif self._key == "end_of_track_sleep":
-            await self.coordinator.async_set_sleep_timer(self.player.id, 0)
-        elif self._key.startswith("alarms"):
-            await self.coordinator.async_enable_disable_alarm(
-                self.player.id, self._index, False
+            return False
+        seconds_to_end = event.track_length - event.position
+        return abs(event.sleep_timer_seconds - seconds_to_end) <= 5
+
+    async def async_turn_on(self, **kwargs) -> None:
+        event = self.player.last_event
+        if event.track_length is not None and event.position is not None:
+            seconds_to_end = event.track_length - event.position
+            await self.coordinator.async_set_sleep_timer(
+                self.player.id, seconds_to_end
             )
         self.async_write_ha_state()
 
+    async def async_turn_off(self, **kwargs) -> None:
+        await self.coordinator.async_set_sleep_timer(self.player.id, 0)
+        self.async_write_ha_state()
+
+
+class YotoAlarmSwitch(SwitchEntity, YotoEntity):
+    """Switch backing one alarm slot (enable / disable)."""
+
+    _attr_translation_key = "alarm"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator, player: YotoPlayer, index: int) -> None:
+        super().__init__(coordinator, player)
+        self._index = index
+        self._attr_unique_id = f"{DOMAIN}_{player.id}_switch_alarms[{index}]"
+        self._attr_translation_placeholders = {"number": str(index + 1)}
+
+    @property
+    def is_on(self) -> bool | None:
+        alarms = self.player.info.config.alarms
+        if 0 <= self._index < len(alarms):
+            return alarms[self._index].enabled
+        return None
+
     async def async_turn_on(self, **kwargs) -> None:
-        """Turn the entity on."""
-        if (
-            self._key == "night_display_brightness"
-            or self._key == "day_display_brightness"
-        ):
-            await self.coordinator.async_set_brightness(
-                self.player.id, self._key, "auto"
-            )
-        elif self._key == "end_of_track_sleep":
-            if (
-                self.player.track_length is not None
-                and self.player.track_position is not None
-            ):
-                seconds_to_end = self.player.track_length - self.player.track_position
-                await self.coordinator.async_set_sleep_timer(
-                    self.player.id, seconds_to_end
-                )
-        elif self._key.startswith("alarms"):
-            await self.coordinator.async_enable_disable_alarm(
-                self.player.id, self._index, True
-            )
+        await self.coordinator.async_enable_disable_alarm(
+            self.player.id, self._index, True
+        )
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        await self.coordinator.async_enable_disable_alarm(
+            self.player.id, self._index, False
+        )
         self.async_write_ha_state()

--- a/custom_components/yoto/time.py
+++ b/custom_components/yoto/time.py
@@ -23,9 +23,7 @@ class YotoTimeEntityDescription(TimeEntityDescription):
     """Yoto time entity."""
 
     value: Callable[[YotoPlayer], time | None]
-    setter: Callable[
-        [YotoDataUpdateCoordinator, YotoPlayer, time], Awaitable[None]
-    ]
+    setter: Callable[[YotoDataUpdateCoordinator, YotoPlayer, time], Awaitable[None]]
 
 
 TIME_DESCRIPTIONS: Final[tuple[YotoTimeEntityDescription, ...]] = (

--- a/custom_components/yoto/time.py
+++ b/custom_components/yoto/time.py
@@ -1,7 +1,9 @@
-"""Time for Yoto integration."""
+"""Time entities for Yoto integration."""
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import time
 from typing import Final
 
@@ -15,15 +17,30 @@ from .const import DOMAIN
 from .coordinator import YotoConfigEntry, YotoDataUpdateCoordinator
 from .entity import YotoEntity
 
-TIME_DESCRIPTIONS: Final[tuple[TimeEntityDescription, ...]] = (
-    TimeEntityDescription(
+
+@dataclass(frozen=True, kw_only=True)
+class YotoTimeEntityDescription(TimeEntityDescription):
+    """Yoto time entity."""
+
+    value: Callable[[YotoPlayer], time | None]
+    setter: Callable[
+        [YotoDataUpdateCoordinator, YotoPlayer, time], Awaitable[None]
+    ]
+
+
+TIME_DESCRIPTIONS: Final[tuple[YotoTimeEntityDescription, ...]] = (
+    YotoTimeEntityDescription(
         key="day_mode_time",
         translation_key="day_mode_time",
+        value=lambda p: p.info.config.day_time,
+        setter=lambda c, p, v: c.async_set_player_config(p.id, day_time=v),
         entity_category=EntityCategory.CONFIG,
     ),
-    TimeEntityDescription(
+    YotoTimeEntityDescription(
         key="night_mode_time",
         translation_key="night_mode_time",
+        value=lambda p: p.info.config.night_time,
+        setter=lambda c, p, v: c.async_set_player_config(p.id, night_time=v),
         entity_category=EntityCategory.CONFIG,
     ),
 )
@@ -37,10 +54,10 @@ async def async_setup_entry(
     """Set up time platform."""
     coordinator = config_entry.runtime_data
     entities: list[YotoTime] = []
-    for player_id in coordinator.yoto_manager.players.keys():
-        player: YotoPlayer = coordinator.yoto_manager.players[player_id]
+    for player_id in coordinator.yoto_client.players.keys():
+        player: YotoPlayer = coordinator.yoto_client.players[player_id]
         for description in TIME_DESCRIPTIONS:
-            if getattr(player.config, description.key, None) is not None:
+            if description.value(player) is not None:
                 entities.append(YotoTime(coordinator, description, player))
     async_add_entities(entities)
 
@@ -48,26 +65,22 @@ async def async_setup_entry(
 class YotoTime(TimeEntity, YotoEntity):
     """Yoto time entity."""
 
+    entity_description: YotoTimeEntityDescription
+
     def __init__(
         self,
-        coordinator: YotoDataUpdateCoordinator,
-        description: TimeEntityDescription,
+        coordinator,
+        description: YotoTimeEntityDescription,
         player: YotoPlayer,
     ) -> None:
-        """Initialize the sensor."""
         super().__init__(coordinator, player)
-        self._description = description
-        self._key = self._description.key
-        self._attr_unique_id = f"{DOMAIN}_{player.id}_{self._description.key}"
-        self._attr_translation_key = self._description.translation_key
-        self._attr_entity_category = description.entity_category
+        self.entity_description = description
+        self._attr_unique_id = f"{DOMAIN}_{player.id}_{description.key}"
 
     @property
     def native_value(self) -> time | None:
-        """Return the value reported by the sensor."""
-        return getattr(self.player.config, self._key)
+        return self.entity_description.value(self.player)
 
     async def async_set_value(self, value: time) -> None:
-        """Update the current time."""
-        await self.coordinator.async_set_time(self.player.id, self._key, value)
+        await self.entity_description.setter(self.coordinator, self.player, value)
         self.async_write_ha_state()

--- a/custom_components/yoto/utils.py
+++ b/custom_components/yoto/utils.py
@@ -1,24 +1,8 @@
 """utils.py"""
 
 import logging
-import re
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def rgetattr(obj: object, attr: str) -> object:
-    """Recursively get nested attributes."""
-    _this_func = rgetattr
-    sp = attr.split(".", 1)
-    if len(sp) == 1:
-        left, right = sp[0], ""
-    else:
-        left, right = sp
-
-    obj = getattr(obj, left)
-    if right:
-        obj = _this_func(obj, right)
-    return obj
 
 
 def split_media_id(text: str) -> tuple[str, str | None, str | None, int]:
@@ -45,17 +29,3 @@ def split_media_id(text: str) -> tuple[str, str | None, str | None, int]:
         trackid = None
         time = 0
     return cardid, chapterid, trackid, time
-
-
-def parse_key(text: str) -> tuple[str, int] | None:
-    """Parse a key string in format 'name[index]'.
-
-    Returns tuple of (name, index) or None if format doesn't match.
-    """
-    match = re.match(r"(\w+)\[(\d+)\]", text)
-
-    if match:
-        object1 = match.group(1)  # This will be 'alarms'
-        object2 = int(match.group(2))  # This will be 1
-        return object1, object2
-    return None


### PR DESCRIPTION
Migrates the integration to a rewritten `yoto-api` library. The new lib has a typed data model that makes the integration code simpler and fixes a few behaviours.

What changes for users:

- The light entity now has a separate brightness slider on top of the colour picker. Before, brightness was folded into the colour, so dimming meant picking a darker shade. You can now dim without changing the hue.
- The light entity is no longer created for the Yoto Mini, which doesn't have an LED ring. `Night light` binary sensor is also hidden on the Mini.
- The `Last updated` sensor now reflects the most recent data refresh from any source, not just live playback events. It stays meaningful when the device is offline.
- The `Sleep timer` binary sensor shows "off" instead of "unavailable" until a playback event arrives.
- The day/night display brightness sliders are properly greyed out when auto mode is on. Turning the auto switch off now actually leaves auto mode (previous version silently did nothing).

Note : The library is pinned to a commit on the `typed_yoto_client_rewrite` branch since v3.0.0 isn't on PyPI yet. Don't merge before the lib release. This branch is the reference consumer for the new API and is useful for catching issues before tagging.

Needs : https://github.com/cdnninja/yoto_api/pull/177

Tested with a Yoto Player and a Yoto Mini.
