### PR TITLE
fix: return no rgb_color while the ambient light is off

### DIFF
--- a/custom_components/yoto/light.py
+++ b/custom_components/yoto/light.py
@@ -79,11 +79,21 @@ class YotoLight(LightEntity, YotoEntity):
         return [ColorMode.RGB]
 
     @property
-    def rgb_color(self) -> tuple[int, int, int]:
-        """Return the RGB color"""
-        hex_val = rgetattr(self.player, self._key).lstrip("#")
-        rgb_val = tuple(int(hex_val[i : i + 2], 16) for i in (0, 2, 4))
-        return rgb_val
+    def rgb_color(self) -> tuple[int, int, int] | None:
+        """Return the RGB color."""
+        raw = rgetattr(self.player, self._key)
+        if not isinstance(raw, str):
+            return None
+        hex_val = raw.lstrip("#")
+        if len(hex_val) != 6:
+            # The player reports "#0" while the ambient light is off, so there
+            # is no color to report.
+            return None
+        return (
+            int(hex_val[0:2], 16),
+            int(hex_val[2:4], 16),
+            int(hex_val[4:6], 16),
+        )
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
## Summary
- return `None` from `rgb_color` unless the stored value is a full six digit hex string
- fixes a `ValueError` that removed both ambient colour lights whenever they were off

The player stores `"#0"` when an ambient light is off, which `is_on` already relies on. `rgb_color` stripped the `#` and sliced `[0:2]`, `[2:4]` and `[4:6]` off the remaining `"0"`, so the last two slices were empty:

```python
hex_val = rgetattr(self.player, self._key).lstrip("#")   # "0"
rgb_val = tuple(int(hex_val[i : i + 2], 16) for i in (0, 2, 4))
# ValueError: invalid literal for int() with base 16: ''
```

`async_setup_entry` adds the entity whenever the attribute `is not None`, and `"#0"` passes that check, so the entity was created and then raised on its first state write:

```
Error adding entity light.<player>_day_ambient_colour for domain light with platform yoto
  File "/config/custom_components/yoto/light.py", line 85, in rgb_color
    rgb_val = tuple(int(hex_val[i : i + 2], 16) for i in (0, 2, 4))
ValueError: invalid literal for int() with base 16: ''
```

Net effect on 3.2.2: `light.<player>_day_ambient_colour` and `light.<player>_night_ambient_colour` are missing for as long as the ambient light is off — which is also when you would most want to set a colour. `None` is a valid `rgb_color`, so the entity now loads and simply reports no colour until one is set.

The `isinstance` check also covers `None`, which reached `.lstrip` and raised `AttributeError` on the same line.

## Testing
- ran Ruff check and Ruff format — both clean
- ran codespell with the repo's ignore list — clean
- ran mypy `--strict --ignore-missing-imports`: errors in `light.py` drop from 7 to 5, with no new ones. This clears the two on the changed lines (`"object" has no attribute "lstrip"` and `Incompatible return value type (got "tuple[int, ...]", expected "tuple[int, int, int]")`); the remaining five are pre-existing and untouched.
- exercised the property directly: `"#0"`, `""`, `None` and `"#fff"` all return `None` instead of raising, while `"#ffffff"`, `"#0a1b2c"` and `"ffffff"` return the same tuples as before
- confirmed against a live 3.2.2 install where both ambient colour lights were failing to load with the traceback above

One deliberate behaviour change worth flagging: a malformed 7+ digit value such as `"#0000000"` previously returned `(0, 0, 0)` by silently truncating, and now returns `None`. Happy to relax that to a prefix check if you would rather keep the old leniency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)